### PR TITLE
fix(security): Harden segment requests, head tags, and env detection

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -6,6 +6,7 @@
       "always",
       [
         "render",
+        "security",
         "layout",
         "hydration",
         "streaming",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -90,6 +90,8 @@
     "test:integration:prod": "TEST_MODE=prod playwright test -c test/integration/playwright.config.ts",
     "test:integration:run": "pnpm test:integration:dev",
     "test:integration:clean": "rm -rf test/integration/fixtures/*/",
+    "test:cli-init": "tsx test/cli-init/smoke.ts",
+    "test:cli-init:clean": "rm -rf test/cli-init/fixtures/*/",
     "test:e2e:setup": "tsx test/e2e/setup/create-fixtures.ts",
     "test:e2e:dev": "TEST_MODE=dev playwright test -c test/e2e/playwright.config.ts",
     "test:e2e:prod": "TEST_MODE=prod playwright test -c test/e2e/playwright.config.ts",

--- a/packages/react/src/__tests__/integration/render-pipeline.integration.spec.ts
+++ b/packages/react/src/__tests__/integration/render-pipeline.integration.spec.ts
@@ -122,6 +122,7 @@ describe('Render Pipeline Integration', () => {
         }),
         expect.anything(),
         undefined,
+        undefined,
       );
 
       // Verify HTML output contains rendered React component
@@ -235,6 +236,7 @@ describe('Render Pipeline Integration', () => {
           title: 'Custom SEO Title',
           description: 'Custom description for search engines',
         }),
+        undefined,
       );
 
       // Check custom head tags
@@ -369,6 +371,7 @@ describe('Render Pipeline Integration', () => {
         }),
         expect.anything(),
         undefined,
+        undefined,
       );
 
       // Check layoutProps were passed correctly
@@ -410,6 +413,7 @@ describe('Render Pipeline Integration', () => {
         'views/test',
         expect.anything(),
         expect.anything(),
+        undefined,
         undefined,
       );
 
@@ -460,6 +464,7 @@ describe('Render Pipeline Integration', () => {
           }),
         }),
         expect.anything(),
+        undefined,
         undefined,
       );
 

--- a/packages/react/src/cli/__tests__/init.spec.ts
+++ b/packages/react/src/cli/__tests__/init.spec.ts
@@ -1,0 +1,497 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const cli = vi.hoisted(() => ({
+  command: null as null | { run: (context: { args: any }) => void },
+  runMain: vi.fn(),
+}));
+
+const mockedConsola = vi.hoisted(() => ({
+  box: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  log: vi.fn(),
+  start: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('citty', () => ({
+  defineCommand: vi.fn((command) => {
+    cli.command = command;
+    return command;
+  }),
+  runMain: cli.runMain,
+}));
+
+vi.mock('consola', () => ({
+  consola: mockedConsola,
+}));
+
+describe('init CLI', () => {
+  const originalCwd = process.cwd();
+  const tempProjects: string[] = [];
+
+  beforeAll(async () => {
+    await import('../init');
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+  });
+
+  afterAll(() => {
+    process.chdir(originalCwd);
+    for (const projectDir of tempProjects) {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  function createProject(options?: {
+    packageJson?: Record<string, unknown>;
+    tsconfig?: Record<string, unknown>;
+    tsconfigBuild?: Record<string, unknown>;
+    nestCli?: Record<string, unknown>;
+    mainTs?: string;
+    appModuleTs?: string;
+  }) {
+    const projectDir = mkdtempSync(join(tmpdir(), 'nestjs-ssr-init-'));
+    tempProjects.push(projectDir);
+
+    mkdirSync(join(projectDir, 'src'), { recursive: true });
+
+    writeJson(
+      projectDir,
+      'package.json',
+      options?.packageJson ?? {
+        scripts: {
+          build: 'nest build',
+          start: 'nest start',
+        },
+        dependencies: {
+          '@nestjs/common': '^11.0.0',
+          '@nestjs/core': '^11.0.0',
+          '@nestjs/platform-express': '^11.0.0',
+        },
+        devDependencies: {},
+      },
+    );
+
+    writeJson(
+      projectDir,
+      'tsconfig.json',
+      options?.tsconfig ?? {
+        compilerOptions: {
+          module: 'commonjs',
+          moduleResolution: 'node',
+        },
+        include: ['src/**/*.ts'],
+        exclude: ['node_modules', 'dist'],
+      },
+    );
+
+    if (options?.tsconfigBuild) {
+      writeJson(projectDir, 'tsconfig.build.json', options.tsconfigBuild);
+    }
+
+    if (options?.nestCli) {
+      writeJson(projectDir, 'nest-cli.json', options.nestCli);
+    }
+
+    writeFileSync(
+      join(projectDir, 'src/main.ts'),
+      options?.mainTs ??
+        `import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+void bootstrap();
+`,
+    );
+
+    writeFileSync(
+      join(projectDir, 'src/app.module.ts'),
+      options?.appModuleTs ??
+        `import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}
+`,
+    );
+
+    return projectDir;
+  }
+
+  function runInit(
+    projectDir: string,
+    args: Partial<{
+      force: boolean;
+      views: string;
+      'skip-install': boolean;
+      port: string;
+    }> = {},
+  ) {
+    expect(cli.command).toBeTruthy();
+    process.chdir(projectDir);
+    cli.command!.run({
+      args: {
+        force: false,
+        views: 'src/views',
+        'skip-install': true,
+        port: '5173',
+        ...args,
+      },
+    });
+  }
+
+  function read(projectDir: string, path: string) {
+    return readFileSync(join(projectDir, path), 'utf-8');
+  }
+
+  function readJson<T>(projectDir: string, path: string): T {
+    return JSON.parse(read(projectDir, path)) as T;
+  }
+
+  function writeJson(
+    projectDir: string,
+    path: string,
+    value: Record<string, unknown>,
+  ) {
+    writeFileSync(join(projectDir, path), JSON.stringify(value, null, 2));
+  }
+
+  function countOccurrences(text: string, value: string) {
+    return text.split(value).length - 1;
+  }
+
+  it('creates a runnable SSR project skeleton for a fresh NestJS app', () => {
+    const projectDir = createProject({
+      nestCli: {
+        compilerOptions: {
+          builder: 'swc',
+          deleteOutDir: true,
+        },
+      },
+      mainTs: `import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  await app.listen(3000);
+}
+void bootstrap();
+`,
+      appModuleTs: `import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}
+`,
+    });
+
+    runInit(projectDir, { port: '4242' });
+
+    const entryClient = read(projectDir, 'src/views/entry-client.tsx');
+    const entryServer = read(projectDir, 'src/views/entry-server.tsx');
+    const indexHtml = read(projectDir, 'src/views/index.html');
+
+    expect(entryClient).toContain('hydrateRoot');
+    expect(entryClient).toContain("import.meta.glob(['@/**/views/**/*.tsx'");
+    expect(entryServer).toContain('renderComponent');
+    expect(entryServer).toContain('renderComponentStream');
+    expect(indexHtml).toContain('<div id="root"><!--app-html--></div>');
+    expect(indexHtml).toContain('<!--initial-state-->');
+    expect(indexHtml).toContain('<!--client-scripts-->');
+
+    const viteConfig = read(projectDir, 'vite.config.ts');
+    expect(viteConfig).toContain('port: 4242');
+    expect(viteConfig).toContain('hmr: { port: 4242 }');
+    expect(viteConfig).toContain(
+      "client: resolve(process.cwd(), 'src/views/entry-client.tsx')",
+    );
+    expect(viteConfig).toContain("id.endsWith('.node')");
+
+    const tsconfig = readJson<{
+      compilerOptions: {
+        module: string;
+        moduleResolution: string;
+        jsx: string;
+        paths: Record<string, string[]>;
+      };
+      include: string[];
+      exclude: string[];
+    }>(projectDir, 'tsconfig.json');
+    expect(tsconfig.compilerOptions).toMatchObject({
+      module: 'nodenext',
+      moduleResolution: 'nodenext',
+      jsx: 'react-jsx',
+    });
+    expect(tsconfig.compilerOptions.paths['@/*']).toEqual(['./src/*']);
+    expect(tsconfig.include).toContain('src/**/*.tsx');
+    expect(tsconfig.exclude).toContain('src/views/entry-client.tsx');
+
+    const tsconfigBuild = readJson<{ extends: string; exclude: string[] }>(
+      projectDir,
+      'tsconfig.build.json',
+    );
+    expect(tsconfigBuild.extends).toBe('./tsconfig.json');
+    expect(tsconfigBuild.exclude).toEqual(
+      expect.arrayContaining([
+        'node_modules',
+        'test',
+        'dist',
+        '**/*spec.ts',
+        'src/views/entry-client.tsx',
+      ]),
+    );
+
+    const nestCli = readJson<{
+      compilerOptions: {
+        builder: {
+          type: string;
+          options: { extensions: string[] };
+        };
+        deleteOutDir: boolean;
+      };
+      exclude: string[];
+    }>(projectDir, 'nest-cli.json');
+    expect(nestCli.compilerOptions.deleteOutDir).toBe(true);
+    expect(nestCli.compilerOptions.builder).toEqual({
+      type: 'swc',
+      options: { extensions: ['.js', '.ts', '.tsx'] },
+    });
+    expect(nestCli.exclude).toContain('**/entry-client.tsx');
+
+    const swcrc = readJson<{
+      jsc: {
+        parser: { tsx: boolean; decorators: boolean };
+        transform: { react: { runtime: string } };
+      };
+    }>(projectDir, '.swcrc');
+    expect(swcrc.jsc.parser.tsx).toBe(true);
+    expect(swcrc.jsc.parser.decorators).toBe(true);
+    expect(swcrc.jsc.transform.react.runtime).toBe('automatic');
+
+    const mainTs = read(projectDir, 'src/main.ts');
+    expect(mainTs).toContain('app.enableShutdownHooks();');
+    expect(mainTs.indexOf('NestFactory.create')).toBeLessThan(
+      mainTs.indexOf('app.enableShutdownHooks();'),
+    );
+
+    const appModule = read(projectDir, 'src/app.module.ts');
+    expect(appModule).toContain(
+      "import { RenderModule } from '@nestjs-ssr/react';",
+    );
+    expect(appModule).toContain(
+      'ConfigModule, RenderModule.forRoot({ vite: { port: 4242 } })',
+    );
+
+    const packageJson = readJson<{
+      scripts: Record<string, string>;
+    }>(projectDir, 'package.json');
+    expect(packageJson.scripts).toMatchObject({
+      build: 'nest build && pnpm build:client && pnpm build:server',
+      'build:client':
+        'vite build --ssrManifest --outDir dist/client && cp src/views/index.html dist/client/index.html',
+      'build:server':
+        'vite build --ssr src/views/entry-server.tsx --outDir dist/server',
+      'dev:vite': 'vite --port 4242',
+      'dev:nest': 'nest start --watch --watchAssets --preserveWatchOutput',
+    });
+    expect(packageJson.scripts['start:dev']).toContain('concurrently --raw');
+  });
+
+  it('honors a custom views directory across generated files and compiler excludes', () => {
+    const projectDir = createProject();
+
+    runInit(projectDir, { views: 'src/ui/pages', port: '3333' });
+
+    expect(existsSync(join(projectDir, 'src/ui/pages/entry-client.tsx'))).toBe(
+      true,
+    );
+    expect(existsSync(join(projectDir, 'src/ui/pages/entry-server.tsx'))).toBe(
+      true,
+    );
+    expect(existsSync(join(projectDir, 'src/ui/pages/index.html'))).toBe(true);
+
+    const tsconfig = readJson<{ exclude: string[] }>(
+      projectDir,
+      'tsconfig.json',
+    );
+    expect(tsconfig.exclude).toContain('src/ui/pages/entry-client.tsx');
+    expect(tsconfig.exclude).not.toContain('src/views/entry-client.tsx');
+
+    const tsconfigBuild = readJson<{ exclude: string[] }>(
+      projectDir,
+      'tsconfig.build.json',
+    );
+    expect(tsconfigBuild.exclude).toContain('src/ui/pages/entry-client.tsx');
+    expect(tsconfigBuild.exclude).not.toContain('src/views/entry-client.tsx');
+
+    const viteConfig = read(projectDir, 'vite.config.ts');
+    expect(viteConfig).toContain(
+      "client: resolve(process.cwd(), 'src/ui/pages/entry-client.tsx')",
+    );
+
+    const packageJson = readJson<{ scripts: Record<string, string> }>(
+      projectDir,
+      'package.json',
+    );
+    expect(packageJson.scripts['build:client']).toContain(
+      'cp src/ui/pages/index.html dist/client/index.html',
+    );
+    expect(packageJson.scripts['build:server']).toContain(
+      'vite build --ssr src/ui/pages/entry-server.tsx --outDir dist/server',
+    );
+
+    const appModule = read(projectDir, 'src/app.module.ts');
+    expect(appModule).toContain(
+      'RenderModule.forRoot({ vite: { port: 3333 } })',
+    );
+  });
+
+  it('preserves existing view entry files unless force is enabled', () => {
+    const projectDir = createProject();
+    mkdirSync(join(projectDir, 'src/views'), { recursive: true });
+    writeFileSync(
+      join(projectDir, 'src/views/entry-client.tsx'),
+      'custom client entry',
+    );
+
+    runInit(projectDir);
+
+    expect(read(projectDir, 'src/views/entry-client.tsx')).toBe(
+      'custom client entry',
+    );
+
+    runInit(projectDir, { force: true });
+
+    expect(read(projectDir, 'src/views/entry-client.tsx')).toContain(
+      'hydrateRoot',
+    );
+  });
+
+  it('is idempotent when rerun on an initialized project', () => {
+    const projectDir = createProject({
+      nestCli: {
+        compilerOptions: {
+          builder: {
+            type: 'swc',
+            options: { extensions: ['.js', '.ts', '.tsx'] },
+          },
+        },
+        exclude: ['dist'],
+      },
+    });
+
+    runInit(projectDir);
+    runInit(projectDir);
+
+    const appModule = read(projectDir, 'src/app.module.ts');
+    expect(
+      countOccurrences(
+        appModule,
+        "import { RenderModule } from '@nestjs-ssr/react';",
+      ),
+    ).toBe(1);
+    expect(countOccurrences(appModule, 'RenderModule.forRoot()')).toBe(1);
+
+    const mainTs = read(projectDir, 'src/main.ts');
+    expect(countOccurrences(mainTs, 'app.enableShutdownHooks();')).toBe(1);
+
+    const tsconfig = readJson<{ exclude: string[] }>(
+      projectDir,
+      'tsconfig.json',
+    );
+    expect(
+      tsconfig.exclude.filter((pattern) =>
+        pattern.includes('entry-client.tsx'),
+      ),
+    ).toEqual(['src/views/entry-client.tsx']);
+
+    const tsconfigBuild = readJson<{ exclude: string[] }>(
+      projectDir,
+      'tsconfig.build.json',
+    );
+    expect(
+      tsconfigBuild.exclude.filter((pattern) =>
+        pattern.includes('entry-client.tsx'),
+      ),
+    ).toEqual(['src/views/entry-client.tsx']);
+
+    const nestCli = readJson<{ exclude: string[] }>(
+      projectDir,
+      'nest-cli.json',
+    );
+    expect(
+      nestCli.exclude.filter((pattern) => pattern.includes('entry-client.tsx')),
+    ).toEqual(['**/entry-client.tsx']);
+  });
+
+  it('preserves existing Vite config and reports the manual config to apply', () => {
+    const projectDir = createProject();
+    writeFileSync(
+      join(projectDir, 'vite.config.ts'),
+      'export default { existing: true };\n',
+    );
+
+    runInit(projectDir, { views: 'src/pages', port: '6060' });
+
+    expect(read(projectDir, 'vite.config.ts')).toBe(
+      'export default { existing: true };\n',
+    );
+    expect(mockedConsola.warn).toHaveBeenCalledWith(
+      'vite.config already exists',
+    );
+    expect(mockedConsola.log).toHaveBeenCalledWith('    port: 6060,');
+    expect(mockedConsola.log).toHaveBeenCalledWith(
+      "      input: { client: resolve(process.cwd(), 'src/pages/entry-client.tsx') }",
+    );
+
+    const packageJson = readJson<{ scripts: Record<string, string> }>(
+      projectDir,
+      'package.json',
+    );
+    expect(packageJson.scripts['build:client']).toContain(
+      'cp src/pages/index.html dist/client/index.html',
+    );
+    expect(packageJson.scripts['build:server']).toContain(
+      'vite build --ssr src/pages/entry-server.tsx --outDir dist/server',
+    );
+    expect(packageJson.scripts['dev:vite']).toBe('vite --port 6060');
+  });
+});

--- a/packages/react/src/cli/init.ts
+++ b/packages/react/src/cli/init.ts
@@ -311,7 +311,7 @@ export default defineConfig({
         pattern.includes('entry-client.tsx'),
       );
       if (!hasEntryClientExclude) {
-        tsconfig.exclude.push('src/views/entry-client.tsx');
+        tsconfig.exclude.push(`${viewsDir}/entry-client.tsx`);
         updated = true;
       }
 
@@ -356,7 +356,7 @@ export default defineConfig({
       );
 
       if (!hasEntryClientExclude) {
-        tsconfigBuild.exclude.push('src/views/entry-client.tsx');
+        tsconfigBuild.exclude.push(`${viewsDir}/entry-client.tsx`);
         buildUpdated = true;
       }
 

--- a/packages/react/src/interfaces/index.ts
+++ b/packages/react/src/interfaces/index.ts
@@ -8,6 +8,7 @@ export type {
   StreamCallbacks,
   ErrorPageDevelopmentProps,
   ContextFactory,
+  CspNonceFactory,
 } from './render-config.interface';
 export type { RenderResponse, HeadData } from './render-response.interface';
 export type {

--- a/packages/react/src/interfaces/render-config.interface.ts
+++ b/packages/react/src/interfaces/render-config.interface.ts
@@ -40,6 +40,26 @@ export type ContextFactory<TRequest extends SSRRequest = SSRRequest> =
   }) => CustomContextProperties | Promise<CustomContextProperties>;
 
 /**
+ * Factory that returns the CSP nonce for the current request.
+ * Called once per rendered page; the returned nonce is added to the
+ * injected hydration scripts so they run under a strict
+ * Content-Security-Policy.
+ *
+ * @example
+ * ```typescript
+ * // With helmet: res.locals.cspNonce
+ * RenderModule.forRoot({
+ *   cspNonce: ({ req }) => (req as any).res?.locals?.cspNonce,
+ * })
+ * ```
+ */
+export type CspNonceFactory<TRequest extends SSRRequest = SSRRequest> =
+  (params: {
+    /** HTTP request object (Express Request or Fastify FastifyRequest) */
+    req: TRequest;
+  }) => string | undefined;
+
+/**
  * SSR rendering mode configuration
  */
 export type SSRMode = 'string' | 'stream';
@@ -90,6 +110,22 @@ export interface RenderConfig {
    * @default 'string'
    */
   mode?: SSRMode;
+
+  /**
+   * Explicit runtime environment, taking precedence over NODE_ENV
+   *
+   * By default the environment is derived from NODE_ENV, and an *unset*
+   * NODE_ENV is treated as development (fail-open) to keep the zero-config
+   * dev experience. Development mode proxies project sources through the
+   * Vite dev server and exposes error stack traces, so deployments that
+   * cannot guarantee NODE_ENV should set this explicitly.
+   *
+   * @example
+   * ```typescript
+   * RenderModule.forRoot({ environment: 'production' })
+   * ```
+   */
+  environment?: 'development' | 'production';
 
   /**
    * Timeout in milliseconds for SSR rendering.
@@ -238,6 +274,38 @@ export interface RenderConfig {
    * ```
    */
   allowedCookies?: string[];
+
+  /**
+   * Enable client-side navigation segment rendering
+   *
+   * When enabled (default), GET requests carrying the X-Current-Layouts
+   * header receive a JSON segment response (rendered HTML + props) used by
+   * the client-side <Link> navigation.
+   *
+   * Set to false to disable segment responses entirely. Note that segment
+   * responses expose page props as JSON (the same data embedded in the HTML
+   * payload), independent of the jsonApi setting - disable this if your
+   * app must not serve machine-readable page data.
+   *
+   * @default true
+   */
+  clientNavigation?: boolean;
+
+  /**
+   * Factory returning a per-request CSP nonce
+   *
+   * When provided, the nonce is added to all script tags the library
+   * injects (hydration state and client entry), allowing a strict
+   * Content-Security-Policy without 'unsafe-inline'.
+   *
+   * @example
+   * ```typescript
+   * RenderModule.forRoot({
+   *   cspNonce: ({ req }) => (req as any).res?.locals?.cspNonce,
+   * })
+   * ```
+   */
+  cspNonce?: CspNonceFactory;
 
   /**
    * Context factory function to enrich RenderContext with custom properties

--- a/packages/react/src/render/__tests__/component-name.util.spec.ts
+++ b/packages/react/src/render/__tests__/component-name.util.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getComponentName,
+  getLayoutName,
+  isValidComponentName,
+  LAYOUT_NAME_FALLBACK,
+  serializeLayoutMetadata,
+} from '../component-name.util';
+
+describe('component-name.util', () => {
+  it('prefers displayName over function name for public component identity', () => {
+    function MinifiedName() {
+      return null;
+    }
+    MinifiedName.displayName = 'PublicName';
+
+    expect(getComponentName(MinifiedName)).toBe('PublicName');
+  });
+
+  it('uses distinct fallbacks for pages and layouts', () => {
+    expect(getComponentName({ displayName: undefined, name: '' })).toBe(
+      'Component',
+    );
+    expect(getLayoutName({ displayName: undefined, name: '' })).toBe(
+      LAYOUT_NAME_FALLBACK,
+    );
+  });
+
+  it('serializes only layout names and props, never component functions', () => {
+    function RootLayout() {
+      return null;
+    }
+    RootLayout.displayName = 'RootLayout';
+
+    const result = serializeLayoutMetadata([
+      { layout: RootLayout, props: { theme: 'dark' } },
+      { layout: { displayName: undefined, name: '' }, props: undefined },
+    ]);
+
+    expect(result).toEqual([
+      { name: 'RootLayout', props: { theme: 'dark' } },
+      { name: 'Layout', props: undefined },
+    ]);
+    expect(JSON.stringify(result)).not.toContain('function');
+  });
+
+  it('accepts plausible generated names from files, identifiers, and unicode components', () => {
+    expect(isValidComponentName('RootLayout')).toBe(true);
+    expect(isValidComponentName('products.index-page')).toBe(true);
+    expect(isValidComponentName('Price$Card_2')).toBe(true);
+    expect(isValidComponentName('ÉtéLayout')).toBe(true);
+  });
+
+  it('rejects empty, invisible, whitespace, markup, and oversized names', () => {
+    expect(isValidComponentName('')).toBe(false);
+    expect(isValidComponentName('Root Layout')).toBe(false);
+    expect(isValidComponentName('Root\u200BLayout')).toBe(false);
+    expect(isValidComponentName('<script>alert(1)</script>')).toBe(false);
+    expect(isValidComponentName('A'.repeat(129))).toBe(false);
+  });
+});

--- a/packages/react/src/render/__tests__/environment.util.spec.ts
+++ b/packages/react/src/render/__tests__/environment.util.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Logger } from '@nestjs/common';
+import {
+  isDevelopmentEnv,
+  setEnvironmentOverride,
+  warnIfNodeEnvUnset,
+  resetEnvironmentForTests,
+} from '../environment.util';
+
+describe('environment.util', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let logger: { warn: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    resetEnvironmentForTests();
+    delete process.env.NODE_ENV;
+    logger = { warn: vi.fn() };
+  });
+
+  afterEach(() => {
+    resetEnvironmentForTests();
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  describe('isDevelopmentEnv', () => {
+    it('treats unset NODE_ENV as development (fail-open default)', () => {
+      expect(isDevelopmentEnv()).toBe(true);
+    });
+
+    it('treats NODE_ENV=production as production', () => {
+      process.env.NODE_ENV = 'production';
+      expect(isDevelopmentEnv()).toBe(false);
+    });
+
+    it('lets the environment override win over an unset NODE_ENV', () => {
+      setEnvironmentOverride('production');
+      expect(isDevelopmentEnv()).toBe(false);
+    });
+
+    it('lets the environment override win over NODE_ENV', () => {
+      process.env.NODE_ENV = 'production';
+      setEnvironmentOverride('development');
+      expect(isDevelopmentEnv()).toBe(true);
+    });
+  });
+
+  describe('warnIfNodeEnvUnset', () => {
+    it('warns once per process when NODE_ENV is unset', () => {
+      warnIfNodeEnvUnset(logger as unknown as Logger);
+      warnIfNodeEnvUnset(logger as unknown as Logger);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not warn when NODE_ENV is set', () => {
+      process.env.NODE_ENV = 'production';
+      warnIfNodeEnvUnset(logger as unknown as Logger);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when the environment is explicitly configured', () => {
+      setEnvironmentOverride('production');
+      warnIfNodeEnvUnset(logger as unknown as Logger);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/src/render/__tests__/render.interceptor.spec.ts
+++ b/packages/react/src/render/__tests__/render.interceptor.spec.ts
@@ -136,6 +136,7 @@ describe('RenderInterceptor', () => {
         }),
         mockResponse,
         undefined,
+        undefined,
       );
     });
 
@@ -179,6 +180,7 @@ describe('RenderInterceptor', () => {
           title: 'User Profile',
           description: 'User profile page',
         },
+        undefined,
       );
     });
 

--- a/packages/react/src/render/__tests__/render.service.spec.ts
+++ b/packages/react/src/render/__tests__/render.service.spec.ts
@@ -1007,7 +1007,7 @@ describe('RenderService', () => {
       );
     });
 
-    it('should cache root layout result after first check', async () => {
+    it('should reload root layout on each call in development (HMR)', async () => {
       const MockRootLayout = () => null;
       MockRootLayout.displayName = 'RootLayout';
 
@@ -1035,15 +1035,14 @@ describe('RenderService', () => {
       expect(rootLayout1).toBe(MockRootLayout);
       expect(mockVite.ssrLoadModule).toHaveBeenCalledTimes(1);
 
-      // Second call - should return cached result
+      // Second call - reloads through Vite so layout edits are picked up.
+      // Vite caches unchanged modules internally, so this is cheap.
       const rootLayout2 = await service.getRootLayout();
       expect(rootLayout2).toBe(MockRootLayout);
-      expect(rootLayout2).toBe(rootLayout1);
-      // Should not call ssrLoadModule again
-      expect(mockVite.ssrLoadModule).toHaveBeenCalledTimes(1);
+      expect(mockVite.ssrLoadModule).toHaveBeenCalledTimes(2);
     });
 
-    it('should cache null result when no layout found', async () => {
+    it('should re-check for a root layout in development when none was found', async () => {
       vi.mocked(existsSync).mockImplementation((filePath: any) => {
         const pathStr = String(filePath);
         if (pathStr.includes('index.html')) return true;
@@ -1058,12 +1057,13 @@ describe('RenderService', () => {
 
       const existsSyncCallCount = vi.mocked(existsSync).mock.calls.length;
 
-      // Second call - should return cached null
+      // Second call - checks again so a newly created layout.tsx is
+      // discovered without restarting the dev server
       const rootLayout2 = await service.getRootLayout();
       expect(rootLayout2).toBeNull();
-
-      // Should not call existsSync again (cached)
-      expect(vi.mocked(existsSync).mock.calls.length).toBe(existsSyncCallCount);
+      expect(vi.mocked(existsSync).mock.calls.length).toBeGreaterThan(
+        existsSyncCallCount,
+      );
     });
 
     it('should handle errors gracefully and return null', async () => {

--- a/packages/react/src/render/__tests__/segment-security.spec.ts
+++ b/packages/react/src/render/__tests__/segment-security.spec.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { RenderInterceptor } from '../render.interceptor';
+import { Reflector } from '@nestjs/core';
+import { RenderService } from '../render.service';
+import type { ExecutionContext, CallHandler } from '@nestjs/common';
+import type { Request, Response } from 'express';
+import { of, firstValueFrom } from 'rxjs';
+import {
+  RENDER_KEY,
+  RENDER_OPTIONS_KEY,
+} from '../../decorators/react-render.decorator';
+import { LAYOUT_KEY } from '../../decorators/layout.decorator';
+
+describe('RenderInterceptor — segment request hardening', () => {
+  let mockReflector: Reflector;
+  let mockRenderService: {
+    render: ReturnType<typeof vi.fn>;
+    renderSegment: ReturnType<typeof vi.fn>;
+    getRootLayout: ReturnType<typeof vi.fn>;
+  };
+  let mockExecutionContext: ExecutionContext;
+  let mockCallHandler: CallHandler;
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+
+  const TestComponent = () => null;
+  TestComponent.displayName = 'TestComponent';
+
+  const RootLayout = () => null;
+  RootLayout.displayName = 'RootLayout';
+
+  beforeEach(() => {
+    mockReflector = {
+      get: vi.fn(),
+    } as unknown as Reflector;
+
+    mockRenderService = {
+      render: vi.fn().mockResolvedValue('<html>Full Page</html>'),
+      renderSegment: vi.fn().mockResolvedValue({
+        html: '<div>Segment</div>',
+        swapTarget: 'RootLayout',
+      }),
+      getRootLayout: vi.fn().mockResolvedValue(RootLayout),
+    };
+
+    mockRequest = {
+      url: '/test',
+      path: '/test',
+      method: 'GET',
+      query: {},
+      params: {},
+      headers: {},
+    } as unknown as Request;
+
+    mockResponse = {
+      type: vi.fn(),
+    } as Partial<Response>;
+
+    mockExecutionContext = {
+      getHandler: vi.fn(),
+      getClass: vi.fn(),
+      switchToHttp: vi.fn().mockReturnValue({
+        getRequest: () => mockRequest,
+        getResponse: () => mockResponse,
+      }),
+    } as unknown as ExecutionContext;
+
+    mockCallHandler = {
+      handle: vi.fn().mockReturnValue(of({ message: 'hello' })),
+    } as unknown as CallHandler;
+
+    vi.mocked(mockReflector.get).mockImplementation((key: unknown) => {
+      if (key === RENDER_KEY) return TestComponent;
+      if (key === RENDER_OPTIONS_KEY) return undefined;
+      if (key === LAYOUT_KEY) return undefined;
+      return undefined;
+    });
+  });
+
+  function createInterceptor(clientNavigation?: boolean) {
+    return new RenderInterceptor(
+      mockReflector,
+      mockRenderService as unknown as RenderService,
+      undefined, // allowedHeaders
+      undefined, // allowedCookies
+      undefined, // contextFactory
+      undefined, // jsonApiEnabled
+      clientNavigation,
+    );
+  }
+
+  it('should serve a segment for a valid X-Current-Layouts header', async () => {
+    const interceptor = createInterceptor();
+    mockRequest.headers = { 'x-current-layouts': 'RootLayout' };
+
+    const result = await firstValueFrom(
+      interceptor.intercept(mockExecutionContext, mockCallHandler),
+    );
+
+    expect(mockRenderService.renderSegment).toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({ swapTarget: 'RootLayout' }),
+    );
+  });
+
+  it('should fall back to full render when header has invalid characters', async () => {
+    const interceptor = createInterceptor();
+    mockRequest.headers = {
+      'x-current-layouts': '<script>alert(1)</script>',
+    };
+
+    const result = await firstValueFrom(
+      interceptor.intercept(mockExecutionContext, mockCallHandler),
+    );
+
+    expect(mockRenderService.renderSegment).not.toHaveBeenCalled();
+    expect(result).toBe('<html>Full Page</html>');
+  });
+
+  it('should accept layout names with accented (non-ASCII) letters', async () => {
+    const interceptor = createInterceptor();
+    mockRequest.headers = { 'x-current-layouts': 'ÉtéLayout' };
+
+    const result = await firstValueFrom(
+      interceptor.intercept(mockExecutionContext, mockCallHandler),
+    );
+
+    // Valid name shape: treated as a segment request. The name matches no
+    // layout in the chain, so the server signals a full client navigation
+    // instead of silently discarding the header.
+    expect(mockRenderService.render).not.toHaveBeenCalled();
+    expect(result).toEqual({ swapTarget: null });
+  });
+
+  it('should fall back to full render when a name contains invisible characters', async () => {
+    const interceptor = createInterceptor();
+    // Zero-width space embedded in an otherwise plausible name
+    mockRequest.headers = { 'x-current-layouts': 'Root\u200BLayout' };
+
+    const result = await firstValueFrom(
+      interceptor.intercept(mockExecutionContext, mockCallHandler),
+    );
+
+    expect(mockRenderService.renderSegment).not.toHaveBeenCalled();
+    expect(result).toBe('<html>Full Page</html>');
+  });
+
+  it('should fall back to full render when header has too many layout names', async () => {
+    const interceptor = createInterceptor();
+    mockRequest.headers = {
+      'x-current-layouts': Array.from({ length: 21 }, (_, i) => `L${i}`).join(
+        ',',
+      ),
+    };
+
+    const result = await firstValueFrom(
+      interceptor.intercept(mockExecutionContext, mockCallHandler),
+    );
+
+    expect(mockRenderService.renderSegment).not.toHaveBeenCalled();
+    expect(result).toBe('<html>Full Page</html>');
+  });
+
+  it('should fall back to full render when header contains an overly long name', async () => {
+    const interceptor = createInterceptor();
+    mockRequest.headers = { 'x-current-layouts': 'A'.repeat(129) };
+
+    const result = await firstValueFrom(
+      interceptor.intercept(mockExecutionContext, mockCallHandler),
+    );
+
+    expect(mockRenderService.renderSegment).not.toHaveBeenCalled();
+    expect(result).toBe('<html>Full Page</html>');
+  });
+
+  it('should ignore the segment header entirely when clientNavigation is disabled', async () => {
+    const interceptor = createInterceptor(false);
+    mockRequest.headers = { 'x-current-layouts': 'RootLayout' };
+
+    const result = await firstValueFrom(
+      interceptor.intercept(mockExecutionContext, mockCallHandler),
+    );
+
+    expect(mockRenderService.renderSegment).not.toHaveBeenCalled();
+    expect(result).toBe('<html>Full Page</html>');
+  });
+
+  it('should keep serving segments when clientNavigation is explicitly enabled', async () => {
+    const interceptor = createInterceptor(true);
+    mockRequest.headers = { 'x-current-layouts': 'RootLayout' };
+
+    await firstValueFrom(
+      interceptor.intercept(mockExecutionContext, mockCallHandler),
+    );
+
+    expect(mockRenderService.renderSegment).toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/render/__tests__/stream-renderer.spec.ts
+++ b/packages/react/src/render/__tests__/stream-renderer.spec.ts
@@ -1,0 +1,188 @@
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { StreamRenderer } from '../renderers/stream-renderer';
+import { TemplateParserService } from '../template-parser.service';
+import { StreamingErrorHandler } from '../streaming-error-handler';
+import type { StreamRenderContext } from '../renderers/stream-renderer';
+
+const serverModule = vi.hoisted(() => ({
+  loadServerModule: vi.fn(),
+}));
+
+vi.mock('../server-module-loader', () => ({
+  loadServerModule: serverModule.loadServerModule,
+}));
+
+const Page = () => null;
+Page.displayName = 'ContractPage';
+
+describe('StreamRenderer', () => {
+  let renderer: StreamRenderer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    renderer = new StreamRenderer(
+      new TemplateParserService(),
+      new StreamingErrorHandler(),
+    );
+  });
+
+  function createResponse() {
+    const stream = new PassThrough();
+    const chunks: string[] = [];
+    const response = stream as PassThrough & {
+      headersSent: boolean;
+      statusCode: number;
+      setHeader: ReturnType<typeof vi.fn>;
+      write: ReturnType<typeof vi.fn>;
+      end: ReturnType<typeof vi.fn>;
+      on: ReturnType<typeof vi.fn>;
+    };
+
+    response.headersSent = false;
+    response.statusCode = 200;
+    response.setHeader = vi.fn();
+
+    const originalWrite = stream.write.bind(stream);
+    response.write = vi.fn((chunk: any, ...args: any[]) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk.toString('utf-8') : chunk);
+      response.headersSent = true;
+      return originalWrite(chunk, ...args);
+    });
+
+    const originalEnd = stream.end.bind(stream);
+    response.end = vi.fn((chunk?: any, ...args: any[]) => {
+      if (chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk.toString('utf-8') : chunk);
+      }
+      return originalEnd(chunk, ...args);
+    });
+
+    const originalOn = stream.on.bind(stream);
+    response.on = vi.fn((event: string, handler: (...args: any[]) => void) => {
+      originalOn(event, handler);
+      return response;
+    });
+
+    return { response, chunks };
+  }
+
+  function context(template: string): StreamRenderContext {
+    return {
+      template,
+      vite: null,
+      manifest: {
+        'src/views/entry-client.tsx': {
+          file: 'assets/entry-client.js',
+          isEntry: true,
+          css: ['assets/app.css'],
+        },
+      },
+      serverManifest: null,
+      entryServerPath: '/src/views/entry-server.tsx',
+      isDevelopment: false,
+      nonce: 'nonce-123',
+    };
+  }
+
+  function mockStreamingModule(html: string) {
+    const abort = vi.fn();
+    const pipe = vi.fn((destination: PassThrough) => {
+      destination.write(html);
+      destination.end();
+    });
+
+    serverModule.loadServerModule.mockResolvedValue({
+      renderComponentStream: vi.fn((_component, _data, callbacks) => {
+        queueMicrotask(() => {
+          callbacks.onShellReady();
+          callbacks.onAllReady?.();
+        });
+        return { pipe, abort };
+      }),
+    });
+
+    return { abort, pipe };
+  }
+
+  it('streams hydration scripts outside the root div with nonce and manifest assets', async () => {
+    mockStreamingModule('<main>Streamed page</main>');
+    const { response, chunks } = createResponse();
+
+    await renderer.render(
+      Page,
+      {
+        data: { price: "costs $' literally" },
+        __context: { path: '/stream' },
+        __layouts: [],
+      },
+      response,
+      context(`<!DOCTYPE html>
+<html>
+<head>
+  <!--head-meta-->
+  <!--styles-->
+</head>
+<body>
+  <div id="root"><!--app-html--></div>
+  <!--initial-state-->
+  <!--client-scripts-->
+</body>
+</html>`),
+      { title: 'Streaming Contract' },
+    );
+
+    const html = chunks.join('');
+    const rootStart = html.indexOf('<div id="root">');
+    const rootEnd = html.indexOf('</div>', rootStart);
+    const rootHtml = html.slice(rootStart, rootEnd);
+    const inlineScript = html.indexOf('window.__INITIAL_STATE__');
+    const clientScript = html.indexOf('src="/assets/entry-client.js"');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.setHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'text/html; charset=utf-8',
+    );
+    expect(html).toContain('<title>Streaming Contract</title>');
+    expect(html).toContain('<link rel="stylesheet" href="/assets/app.css" />');
+    expect(rootHtml).toContain('<main>Streamed page</main>');
+    expect(rootHtml).not.toContain('window.__INITIAL_STATE__');
+    expect(rootHtml).not.toContain('entry-client.js');
+    expect(inlineScript).toBeGreaterThan(rootEnd);
+    expect(clientScript).toBeGreaterThan(inlineScript);
+    expect(html).toContain('<script nonce="nonce-123">');
+    expect(html).toContain(
+      '<script type="module" nonce="nonce-123" src="/assets/entry-client.js"></script>',
+    );
+    expect(html).toContain("costs $' literally");
+    expect(html.match(/<\/html>/g)).toHaveLength(1);
+  });
+
+  it('appends hydration scripts after the root when legacy templates omit script placeholders', async () => {
+    mockStreamingModule('<section>Legacy template</section>');
+    const { response, chunks } = createResponse();
+
+    await renderer.render(
+      Page,
+      { data: {}, __context: {}, __layouts: [] },
+      response,
+      context(`<!DOCTYPE html>
+<html>
+<head><!--head-meta--><!--styles--></head>
+<body><div id="root"><!--app-html--></div></body>
+</html>`),
+    );
+
+    const html = chunks.join('');
+    const rootEnd = html.indexOf('</div>');
+    const inlineScript = html.indexOf('window.__INITIAL_STATE__');
+    const clientScript = html.indexOf('src="/assets/entry-client.js"');
+    const bodyEnd = html.indexOf('</body>');
+
+    expect(rootEnd).toBeGreaterThan(-1);
+    expect(inlineScript).toBeGreaterThan(rootEnd);
+    expect(clientScript).toBeGreaterThan(inlineScript);
+    expect(bodyEnd).toBeGreaterThan(clientScript);
+  });
+});

--- a/packages/react/src/render/__tests__/string-renderer.spec.ts
+++ b/packages/react/src/render/__tests__/string-renderer.spec.ts
@@ -298,6 +298,26 @@ describe('StringRenderer', () => {
       expect(result).toContain('window.__LAYOUTS__');
     });
 
+    it('should not interpret $ replacement patterns in user data', async () => {
+      const context = makeDevContext();
+
+      // "$'" in String.replace replacement strings splices in the rest of
+      // the subject string - user data must be injected literally
+      const result = await renderer.render(
+        MockPage,
+        {
+          data: { price: "costs $' and $& and $`" },
+          __context: {},
+          __layouts: [],
+        },
+        context,
+      );
+
+      expect(result).toContain("costs $' and $& and $`");
+      // No duplicated template content from a misinterpreted replacement
+      expect(result.match(/<\/html>/g)).toHaveLength(1);
+    });
+
     it('should inject head tags via TemplateParserService', async () => {
       const context = makeDevContext();
 

--- a/packages/react/src/render/__tests__/string-renderer.spec.ts
+++ b/packages/react/src/render/__tests__/string-renderer.spec.ts
@@ -238,7 +238,7 @@ describe('StringRenderer', () => {
       expect(result).toContain('NamedLayout');
     });
 
-    it('should use "default" for anonymous layout functions', async () => {
+    it('should use the shared "Layout" fallback for anonymous layout functions', async () => {
       const context = makeDevContext();
 
       const result = await renderer.render(
@@ -254,7 +254,8 @@ describe('StringRenderer', () => {
       );
 
       expect(result).toContain('window.__LAYOUTS__');
-      expect(result).toContain('default');
+      // Must match the data-layout fallback in the entry templates
+      expect(result).toContain('{name:"Layout"');
     });
 
     it('should fallback to "Component" when viewComponent has no name', async () => {

--- a/packages/react/src/render/__tests__/template-parser.service.spec.ts
+++ b/packages/react/src/render/__tests__/template-parser.service.spec.ts
@@ -398,5 +398,87 @@ describe('TemplateParserService', () => {
         '<meta name="viewport" content="width=device-width" />',
       );
     });
+
+    it('should skip attribute names that are not valid HTML identifiers', () => {
+      const head: HeadData = {
+        meta: [
+          {
+            'autofocus onfocus=alert(1)': 'x',
+            name: 'safe',
+            content: 'value',
+          } as any,
+        ],
+      };
+
+      const result = service.buildHeadTags(head);
+
+      expect(result).not.toContain('onfocus');
+      expect(result).toContain('name="safe"');
+      expect(result).toContain('content="value"');
+    });
+  });
+
+  describe('CSP nonce support', () => {
+    it('should add nonce to inline state script when provided', () => {
+      const result = service.buildInlineScripts(
+        { a: 1 },
+        {},
+        'Page',
+        [],
+        'abc123',
+      );
+
+      expect(result).toContain('<script nonce="abc123">');
+    });
+
+    it('should not add a nonce attribute when none is provided', () => {
+      const result = service.buildInlineScripts({ a: 1 }, {}, 'Page', []);
+
+      expect(result).toContain('<script>');
+      expect(result).not.toContain('nonce');
+    });
+
+    it('should escape the nonce value', () => {
+      const result = service.buildInlineScripts(
+        {},
+        {},
+        'Page',
+        [],
+        '"><script>alert(1)</script>',
+      );
+
+      expect(result).not.toContain('"><script>alert(1)</script>>');
+      expect(result).toContain('&quot;&gt;');
+    });
+
+    it('should add nonce to client script tags', () => {
+      const dev = service.getClientScriptTag(true, undefined, 'abc123');
+      expect(dev).toContain('nonce="abc123"');
+
+      const prod = service.getClientScriptTag(
+        false,
+        {
+          'src/views/entry-client.tsx': { file: 'assets/entry-abc.js' },
+        },
+        'abc123',
+      );
+      expect(prod).toContain('nonce="abc123"');
+      expect(prod).toContain('src="/assets/entry-abc.js"');
+    });
+  });
+
+  describe('manifest entry resolution', () => {
+    it('should find client entry by lenient lookup when key differs', () => {
+      const manifest = {
+        'app/frontend/entry-client.tsx': {
+          file: 'assets/entry-client-xyz.js',
+          isEntry: true,
+        },
+      };
+
+      const result = service.getClientScriptTag(false, manifest);
+
+      expect(result).toContain('src="/assets/entry-client-xyz.js"');
+    });
   });
 });

--- a/packages/react/src/render/__tests__/vite-initializer.service.spec.ts
+++ b/packages/react/src/render/__tests__/vite-initializer.service.spec.ts
@@ -120,8 +120,13 @@ describe('ViteInitializerService', () => {
   });
 
   describe('registerSignalHandlers', () => {
-    it('should register SIGTERM and SIGINT handlers via process.once', () => {
+    it('should register SIGTERM and SIGINT handlers via process.once on init', async () => {
       service = createService();
+
+      // Constructor must not touch process-level state
+      expect(processOnceSpy).not.toHaveBeenCalled();
+
+      await service.onModuleInit();
 
       expect(processOnceSpy).toHaveBeenCalledWith(
         'SIGTERM',

--- a/packages/react/src/render/__tests__/vite-initializer.service.spec.ts
+++ b/packages/react/src/render/__tests__/vite-initializer.service.spec.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import {
-  createServer as createHttpServer,
-  request as httpRequest,
-  type Server,
-} from 'node:http';
-import type { AddressInfo, Socket } from 'node:net';
+import type { Socket } from 'node:net';
 
 // Mock vite before importing the service
 vi.mock('vite', () => ({
@@ -91,7 +86,9 @@ describe('ViteInitializerService', () => {
 
     vi.mocked(createViteServer).mockResolvedValue(mockViteServer);
 
-    processOnceSpy = vi.spyOn(process, 'once');
+    processOnceSpy = vi
+      .spyOn(process, 'once')
+      .mockImplementation(() => process);
   });
 
   afterEach(() => {
@@ -416,70 +413,44 @@ describe('ViteInitializerService', () => {
         'proxy-middleware' as any,
       );
 
-      const upgradedServerSockets: Socket[] = [];
-      const realServer: Server = createHttpServer();
-      // Acknowledge the upgrade and keep the socket open (no proxy needed —
-      // we just need an upgraded socket the http.Server has let go of).
-      realServer.on('upgrade', (_req, socket) => {
-        upgradedServerSockets.push(socket);
-        socket.write(
-          'HTTP/1.1 101 Switching Protocols\r\n' +
-            'Upgrade: test\r\n' +
-            'Connection: Upgrade\r\n\r\n',
-        );
-      });
-      await new Promise<void>((resolve) =>
-        realServer.listen(0, '127.0.0.1', resolve),
-      );
-      const { port } = realServer.address() as AddressInfo;
+      service = createService();
+      await service.onModuleInit();
 
-      mockHttpAdapterHost.httpAdapter.getHttpServer = vi
-        .fn()
-        .mockReturnValue(realServer);
+      const onCalls = (mockHttpServer.on as any).mock.calls as [
+        string,
+        (...args: any[]) => void,
+      ][];
+      const upgradeHandler = onCalls.find(([e]) => e === 'upgrade')?.[1];
+      expect(upgradeHandler).toBeDefined();
 
-      try {
-        service = createService();
-        await service.onModuleInit();
+      let closeHandler: (() => void) | undefined;
+      const upgradedSocket = {
+        destroyed: false,
+        once: vi.fn((event: string, handler: () => void) => {
+          if (event === 'close') {
+            closeHandler = handler;
+          }
+          return upgradedSocket;
+        }),
+        destroy: vi.fn(() => {
+          upgradedSocket.destroyed = true;
+          closeHandler?.();
+        }),
+      } as unknown as Socket & {
+        destroyed: boolean;
+        once: ReturnType<typeof vi.fn>;
+        destroy: ReturnType<typeof vi.fn>;
+      };
 
-        // Send an Upgrade request. The 'upgrade' event fires on the http
-        // server; our handler tracks the socket; closeAllConnections won't
-        // reach it.
-        const req = httpRequest({
-          host: '127.0.0.1',
-          port,
-          path: '/',
-          method: 'GET',
-          headers: { Connection: 'Upgrade', Upgrade: 'test' },
-        });
-        const clientSocket = await new Promise<Socket>((resolve, reject) => {
-          req.once('upgrade', (_res, socket) => resolve(socket));
-          req.once('error', reject);
-          req.end();
-        });
-        expect(clientSocket.destroyed).toBe(false);
-        expect((service as any).trackedSockets.size).toBeGreaterThan(0);
+      upgradeHandler!({}, upgradedSocket);
+      expect((service as any).trackedSockets.has(upgradedSocket)).toBe(true);
 
-        const closed = new Promise<void>((resolve) =>
-          clientSocket.once('close', () => resolve()),
-        );
-        await service.onModuleDestroy();
+      await service.onModuleDestroy();
 
-        // Bound the wait so a regression fails fast instead of hanging.
-        await Promise.race([
-          closed,
-          new Promise<void>((_, reject) =>
-            setTimeout(
-              () =>
-                reject(new Error('upgraded socket never closed on shutdown')),
-              1000,
-            ),
-          ),
-        ]);
-        expect(clientSocket.destroyed).toBe(true);
-      } finally {
-        for (const s of upgradedServerSockets) s.destroy();
-        await new Promise<void>((resolve) => realServer.close(() => resolve()));
-      }
+      expect(mockHttpServer.closeAllConnections).toHaveBeenCalled();
+      expect(upgradedSocket.destroy).toHaveBeenCalled();
+      expect(upgradedSocket.destroyed).toBe(true);
+      expect((service as any).trackedSockets.size).toBe(0);
     });
 
     it('destroys tracked sockets on shutdown so the process can exit', async () => {

--- a/packages/react/src/render/component-name.util.ts
+++ b/packages/react/src/render/component-name.util.ts
@@ -1,0 +1,70 @@
+/**
+ * Fallback name for layouts without a displayName or function name.
+ *
+ * IMPORTANT: This must match the `|| 'Layout'` fallback in the entry
+ * templates (entry-server.tsx / entry-client.tsx), which stamp it into
+ * data-layout attributes. The client echoes those names back in the
+ * X-Current-Layouts header, so every producer and consumer of layout
+ * names has to agree on the fallback or segment matching silently fails.
+ */
+export const LAYOUT_NAME_FALLBACK = 'Layout';
+
+/**
+ * Shape of a component name we could have produced: visible letters and
+ * digits (any script), plus the characters that appear in identifiers and
+ * view filenames (`_ . $ -`). Deliberately excludes whitespace, control,
+ * and invisible/format characters (zero-width joiners, BiDi overrides),
+ * so a client-supplied name that "looks" legitimate cannot smuggle
+ * invisible tokens past the comparison logic.
+ */
+const VALID_COMPONENT_NAME = /^[\p{L}\p{N}_.$-]{1,128}$/u;
+
+/**
+ * Whether a client-supplied string is a plausible component name.
+ * Used to validate the X-Current-Layouts header, which is client-controlled.
+ */
+export function isValidComponentName(name: string): boolean {
+  return VALID_COMPONENT_NAME.test(name);
+}
+
+/**
+ * Resolve a stable display name for a component.
+ *
+ * Used for layout identity (segment swap targets, dedupe, data-layout
+ * attributes) and client-side module resolution. Production bundles are
+ * minified, so `Function.name` is unreliable there - components that
+ * participate in client-side navigation should set `displayName`.
+ */
+export function getComponentName(
+  component: { displayName?: string; name?: string } | null | undefined,
+  fallback = 'Component',
+): string {
+  return component?.displayName || component?.name || fallback;
+}
+
+/**
+ * Resolve the display name of a layout component.
+ * Always uses LAYOUT_NAME_FALLBACK so server-side layout names line up with
+ * the data-layout attributes the entry templates render.
+ */
+export function getLayoutName(
+  component: { displayName?: string; name?: string } | null | undefined,
+): string {
+  return getComponentName(component, LAYOUT_NAME_FALLBACK);
+}
+
+/**
+ * Serialize layout metadata (names and props, never functions) for the
+ * client hydration payload and segment responses.
+ */
+export function serializeLayoutMetadata(
+  layouts?: Array<{ layout: any; props?: any }>,
+): Array<{ name: string; props?: any }> {
+  if (!layouts) {
+    return [];
+  }
+  return layouts.map((l) => ({
+    name: getLayoutName(l.layout),
+    props: l.props,
+  }));
+}

--- a/packages/react/src/render/environment.util.ts
+++ b/packages/react/src/render/environment.util.ts
@@ -1,0 +1,57 @@
+import type { Logger } from '@nestjs/common';
+
+let environmentOverride: 'development' | 'production' | null = null;
+let warnedAboutUnsetNodeEnv = false;
+
+/**
+ * Explicitly set the runtime environment, taking precedence over NODE_ENV.
+ * Called by RenderModule when the `environment` config option is provided,
+ * giving deployments that cannot control NODE_ENV a fail-closed switch.
+ */
+export function setEnvironmentOverride(
+  environment: 'development' | 'production',
+): void {
+  environmentOverride = environment;
+}
+
+/**
+ * Whether the app is running in development mode.
+ *
+ * The `environment` config option wins when set. Otherwise this
+ * intentionally treats an *unset* NODE_ENV as development to keep the
+ * zero-config dev experience, but that is a fail-open default: a production
+ * deployment that forgets to set NODE_ENV gets the Vite dev pipeline
+ * (source proxying, stack traces in error pages). Callers should pair this
+ * with warnIfNodeEnvUnset() so the misconfiguration is visible.
+ */
+export function isDevelopmentEnv(): boolean {
+  if (environmentOverride) {
+    return environmentOverride === 'development';
+  }
+  return process.env.NODE_ENV !== 'production';
+}
+
+/**
+ * Log a prominent warning (once per process) when the environment is not
+ * explicitly configured. Running with an unset NODE_ENV enables development
+ * behavior: the Vite dev-server proxy (which exposes project sources) and
+ * detailed error pages.
+ */
+export function warnIfNodeEnvUnset(logger: Logger): void {
+  if (environmentOverride || process.env.NODE_ENV || warnedAboutUnsetNodeEnv) {
+    return;
+  }
+  warnedAboutUnsetNodeEnv = true;
+  logger.warn(
+    'NODE_ENV is not set - running in DEVELOPMENT mode. ' +
+      'Development mode proxies project sources through the Vite dev server and ' +
+      'exposes error stack traces. Set NODE_ENV=production or pass ' +
+      "RenderModule.forRoot({ environment: 'production' }) for production deployments.",
+  );
+}
+
+/** Test-only helper to reset the override and warn-once state. */
+export function resetEnvironmentForTests(): void {
+  environmentOverride = null;
+  warnedAboutUnsetNodeEnv = false;
+}

--- a/packages/react/src/render/render.interceptor.ts
+++ b/packages/react/src/render/render.interceptor.ts
@@ -25,9 +25,15 @@ import type {
   LayoutComponent,
   SegmentResponse,
   ContextFactory,
+  CspNonceFactory,
 } from '../interfaces/index';
 import type { RenderOptions } from '../decorators/react-render.decorator';
 import type { LayoutDecoratorOptions } from '../decorators/layout.decorator';
+import {
+  getComponentName,
+  getLayoutName,
+  isValidComponentName,
+} from './component-name.util';
 
 /**
  * Type guard to check if data is a RenderResponse
@@ -44,6 +50,13 @@ interface LayoutMetadata {
   options?: LayoutDecoratorOptions;
 }
 
+/**
+ * Maximum number of names accepted in the client-controlled
+ * X-Current-Layouts header. Name shape is validated by
+ * isValidComponentName, which lives next to the name generation logic.
+ */
+const MAX_SEGMENT_LAYOUTS = 20;
+
 @Injectable()
 export class RenderInterceptor implements NestInterceptor {
   constructor(
@@ -55,6 +68,12 @@ export class RenderInterceptor implements NestInterceptor {
     @Inject('CONTEXT_FACTORY')
     private contextFactory?: ContextFactory,
     @Optional() @Inject('JSON_API') private jsonApiEnabled?: boolean,
+    @Optional()
+    @Inject('CLIENT_NAVIGATION')
+    private clientNavigationEnabled?: boolean,
+    @Optional()
+    @Inject('CSP_NONCE')
+    private cspNonceFactory?: CspNonceFactory,
   ) {}
 
   /**
@@ -105,13 +124,14 @@ export class RenderInterceptor implements NestInterceptor {
     // Add controller layout if it exists and is different from root layout
     if (controllerLayoutMeta?.layout) {
       // Skip if controller layout is the same as root layout (avoid duplicates)
-      // Compare by name since dynamic imports create different references
-      const rootLayoutName = rootLayout?.displayName || rootLayout?.name;
-      const controllerLayoutName =
-        controllerLayoutMeta.layout.displayName ||
-        controllerLayoutMeta.layout.name;
+      // Compare by name since dynamic imports create different references.
+      // Anonymous root layouts never match - the fallback name is not identity.
+      const rootLayoutName = rootLayout
+        ? rootLayout.displayName || rootLayout.name
+        : null;
       const isDuplicateOfRoot =
-        rootLayout && rootLayoutName && controllerLayoutName === rootLayoutName;
+        !!rootLayoutName &&
+        getComponentName(controllerLayoutMeta.layout) === rootLayoutName;
 
       if (!isDuplicateOfRoot) {
         // Merge: static decorator props + dynamic runtime props
@@ -146,13 +166,22 @@ export class RenderInterceptor implements NestInterceptor {
 
   /**
    * Detect request type based on headers.
-   * - If X-Current-Layouts header is present, this is a segment request
+   * - If X-Current-Layouts header is present (and valid), this is a segment request
    * - Only GET requests can be segments
+   * - Segment handling can be disabled via the clientNavigation config option
+   *
+   * The header is client-controlled, so it is strictly validated: a bounded
+   * number of names, each matching the shape of a component name. Anything
+   * else is treated as a full page request.
    */
   private detectRequestType(request: Request): {
     type: 'full' | 'segment';
     currentLayouts?: string[];
   } {
+    if (this.clientNavigationEnabled === false) {
+      return { type: 'full' };
+    }
+
     // Only GET requests can be segments
     if (request.method !== 'GET') {
       return { type: 'full' };
@@ -160,12 +189,20 @@ export class RenderInterceptor implements NestInterceptor {
 
     const layoutsHeader = request.headers['x-current-layouts'];
 
-    if (layoutsHeader && typeof layoutsHeader === 'string') {
-      const currentLayouts = layoutsHeader.split(',').map((s) => s.trim());
-      return { type: 'segment', currentLayouts };
+    if (!layoutsHeader || typeof layoutsHeader !== 'string') {
+      return { type: 'full' };
     }
 
-    return { type: 'full' };
+    const currentLayouts = layoutsHeader.split(',').map((s) => s.trim());
+
+    if (
+      currentLayouts.length > MAX_SEGMENT_LAYOUTS ||
+      !currentLayouts.every((name) => isValidComponentName(name))
+    ) {
+      return { type: 'full' };
+    }
+
+    return { type: 'segment', currentLayouts };
   }
 
   /**
@@ -176,9 +213,7 @@ export class RenderInterceptor implements NestInterceptor {
     currentLayouts: string[],
     targetLayouts: Array<{ layout: LayoutComponent<any>; props?: any }>,
   ): string | null {
-    const targetNames = targetLayouts.map(
-      (l) => l.layout.displayName || l.layout.name,
-    );
+    const targetNames = targetLayouts.map((l) => getLayoutName(l.layout));
 
     // Find deepest common layout (walk from root toward leaf)
     let commonLayout: string | null = null;
@@ -206,7 +241,7 @@ export class RenderInterceptor implements NestInterceptor {
     swapTarget: string,
   ): Array<{ layout: LayoutComponent<any>; props?: any }> {
     const index = layouts.findIndex(
-      (l) => (l.layout.displayName || l.layout.name) === swapTarget,
+      (l) => getLayoutName(l.layout) === swapTarget,
     );
     // Return layouts from swap target's children onward (exclude the swap target itself)
     return index >= 0 ? layouts.slice(index + 1) : layouts;
@@ -313,10 +348,12 @@ export class RenderInterceptor implements NestInterceptor {
           ? data
           : { props: data };
 
-        // JSON API content negotiation — check before segment detection
-        // Segment requests (X-Current-Layouts) always take priority
-        const hasSegmentHeader = !!request.headers['x-current-layouts'];
-        if (!hasSegmentHeader && this.isJsonRequest(request)) {
+        // Detect segment requests (client-side navigation) once, up front
+        const { type: requestType, currentLayouts } =
+          this.detectRequestType(request);
+
+        // JSON API content negotiation — segment requests take priority
+        if (requestType !== 'segment' && this.isJsonRequest(request)) {
           if (this.isJsonApiEnabled(context)) {
             response.type('application/json');
             return renderResponse.props;
@@ -343,10 +380,7 @@ export class RenderInterceptor implements NestInterceptor {
           __layouts: layoutChain,
         };
 
-        // Check if this is a segment request (client-side navigation)
-        const { type, currentLayouts } = this.detectRequestType(request);
-
-        if (type === 'segment' && currentLayouts) {
+        if (requestType === 'segment' && currentLayouts) {
           const swapTarget = this.determineSwapTarget(
             currentLayouts,
             layoutChain,
@@ -373,32 +407,31 @@ export class RenderInterceptor implements NestInterceptor {
           return result;
         }
 
-        try {
-          // Render the React component with its layout chain
-          // Pass response object for streaming mode support
-          // Pass head data for template injection
-          // Cast response to SSRResponse - Express Response is a superset
-          const html = await this.renderService.render(
-            viewPathOrComponent as string,
-            fullData,
-            response as any,
-            renderResponse.head,
-          );
+        // Resolve the CSP nonce for this request, if the app provides one
+        const nonce = this.cspNonceFactory?.({ req: request as any });
 
-          // In streaming mode, render() returns void and handles response directly
-          // In string mode, render() returns HTML string
-          if (html !== undefined) {
-            // String mode: Set content type and let NestJS handle sending the response
-            response.type('text/html');
-            return html;
-          }
+        // Render the React component with its layout chain
+        // Pass response object for streaming mode support
+        // Pass head data for template injection
+        // Cast response to SSRResponse - Express Response is a superset
+        const html = await this.renderService.render(
+          viewPathOrComponent as string,
+          fullData,
+          response as any,
+          renderResponse.head,
+          nonce,
+        );
 
-          // Streaming mode: Response already sent, return empty to prevent NestJS from sending again
-          return;
-        } catch (error) {
-          // Re-throw error - let NestJS exception layer handle it
-          throw error;
+        // In streaming mode, render() returns void and handles response directly
+        // In string mode, render() returns HTML string
+        if (html !== undefined) {
+          // String mode: Set content type and let NestJS handle sending the response
+          response.type('text/html');
+          return html;
         }
+
+        // Streaming mode: Response already sent, return empty to prevent NestJS from sending again
+        return;
       }),
     );
   }

--- a/packages/react/src/render/render.module.ts
+++ b/packages/react/src/render/render.module.ts
@@ -6,6 +6,7 @@ import { TemplateParserService } from './template-parser.service';
 import { StreamingErrorHandler } from './streaming-error-handler';
 import { ViteInitializerService } from './vite-initializer.service';
 import { StringRenderer, StreamRenderer } from './renderers';
+import { setEnvironmentOverride } from './environment.util';
 import type { RenderConfig } from '../interfaces';
 
 @Global()
@@ -56,6 +57,10 @@ export class RenderModule {
    * ```
    */
   static forRoot(config?: RenderConfig): DynamicModule {
+    if (config?.environment) {
+      setEnvironmentOverride(config.environment);
+    }
+
     const providers: Provider[] = [
       RenderService,
       TemplateParserService,
@@ -124,6 +129,18 @@ export class RenderModule {
       useValue: config?.jsonApi ?? false,
     });
 
+    providers.push({
+      provide: 'CLIENT_NAVIGATION',
+      useValue: config?.clientNavigation ?? true,
+    });
+
+    if (config?.cspNonce) {
+      providers.push({
+        provide: 'CSP_NONCE',
+        useValue: config.cspNonce,
+      });
+    }
+
     if (config?.context) {
       providers.push({
         provide: 'CONTEXT_FACTORY',
@@ -182,7 +199,15 @@ export class RenderModule {
   }): DynamicModule {
     const configProvider: Provider = {
       provide: 'RENDER_CONFIG',
-      useFactory: options.useFactory,
+      // Resolve the user factory, then apply the environment override before
+      // any config-dependent provider (and thus RenderService) instantiates.
+      useFactory: async (...args: unknown[]) => {
+        const config = await options.useFactory(...args);
+        if (config?.environment) {
+          setEnvironmentOverride(config.environment);
+        }
+        return config;
+      },
       inject: options.inject || [],
     };
 
@@ -246,6 +271,16 @@ export class RenderModule {
       {
         provide: 'JSON_API',
         useFactory: (config: RenderConfig) => config?.jsonApi ?? false,
+        inject: ['RENDER_CONFIG'],
+      },
+      {
+        provide: 'CLIENT_NAVIGATION',
+        useFactory: (config: RenderConfig) => config?.clientNavigation ?? true,
+        inject: ['RENDER_CONFIG'],
+      },
+      {
+        provide: 'CSP_NONCE',
+        useFactory: (config: RenderConfig) => config?.cspNonce,
         inject: ['RENDER_CONFIG'],
       },
     ];

--- a/packages/react/src/render/render.service.ts
+++ b/packages/react/src/render/render.service.ts
@@ -10,16 +10,8 @@ import type {
 } from '../interfaces';
 import { StringRenderer } from './renderers/string-renderer';
 import { StreamRenderer } from './renderers/stream-renderer';
-
-interface ViteManifest {
-  [key: string]: {
-    file: string;
-    src?: string;
-    isEntry?: boolean;
-    imports?: string[];
-    css?: string[];
-  };
-}
+import type { RendererContext, ViteManifest } from './server-module-loader';
+import { isDevelopmentEnv, warnIfNodeEnvUnset } from './environment.util';
 
 /**
  * Main render service that orchestrates SSR rendering
@@ -37,7 +29,7 @@ interface ViteManifest {
  *
  * Stream mode is available for advanced use cases requiring:
  * - Better TTFB (Time to First Byte)
- * - Progressive rendering with Suspense
+ * - Progressive rendering with Suspense support
  */
 @Injectable()
 export class RenderService {
@@ -51,6 +43,7 @@ export class RenderService {
   private readonly entryServerPath: string;
   private rootLayout: any | null | undefined = undefined;
   private rootLayoutChecked = false;
+  private rootLayoutDevPath: string | null = null;
 
   constructor(
     private readonly stringRenderer: StringRenderer,
@@ -59,7 +52,9 @@ export class RenderService {
     @Optional() @Inject('DEFAULT_HEAD') private readonly defaultHead?: HeadData,
     @Optional() @Inject('CUSTOM_TEMPLATE') customTemplate?: string,
   ) {
-    this.isDevelopment = process.env.NODE_ENV !== 'production';
+    this.isDevelopment = isDevelopmentEnv();
+    warnIfNodeEnvUnset(this.logger);
+
     // Default to 'string' mode - simpler, atomic responses, proper HTTP status codes
     this.ssrMode = ssrMode || (process.env.SSR_MODE as SSRMode) || 'string';
 
@@ -208,34 +203,48 @@ export class RenderService {
    * - src/views/layout.tsx
    * - src/views/layout/index.tsx
    * - src/views/_layout.tsx
+   *
+   * In development the layout is re-loaded through Vite on every call so
+   * edits to the layout file are picked up (Vite caches unchanged modules,
+   * so this is cheap). Once a layout file is found its path is cached;
+   * filesystem probing only repeats while none exists, so a layout created
+   * after startup is still discovered. In production the resolved layout
+   * is cached forever.
    */
   async getRootLayout(): Promise<any | null> {
-    if (this.rootLayoutChecked) {
+    if (this.rootLayoutChecked && !this.vite) {
       return this.rootLayout;
     }
-
-    this.rootLayoutChecked = true;
-
-    const conventionalPaths = [
-      'src/views/layout.tsx',
-      'src/views/layout/index.tsx',
-      'src/views/_layout.tsx',
-    ];
 
     try {
       // In development, use Vite's SSR module loader
       if (this.vite) {
-        for (const path of conventionalPaths) {
-          const absolutePath = join(process.cwd(), path);
-          if (!existsSync(absolutePath)) {
-            continue;
+        if (!this.rootLayoutDevPath) {
+          const conventionalPaths = [
+            'src/views/layout.tsx',
+            'src/views/layout/index.tsx',
+            'src/views/_layout.tsx',
+          ];
+          this.rootLayoutDevPath =
+            conventionalPaths.find((path) =>
+              existsSync(join(process.cwd(), path)),
+            ) ?? null;
+          if (this.rootLayoutDevPath) {
+            this.logger.log(`✓ Found root layout at ${this.rootLayoutDevPath}`);
           }
+        }
+        this.rootLayoutChecked = true;
 
-          this.logger.log(`✓ Found root layout at ${path}`);
-          const layoutModule = await this.vite.ssrLoadModule('/' + path);
+        if (this.rootLayoutDevPath) {
+          const layoutModule = await this.vite.ssrLoadModule(
+            '/' + this.rootLayoutDevPath,
+          );
           this.rootLayout = layoutModule.default;
           return this.rootLayout;
         }
+
+        this.rootLayout = null;
+        return null;
       } else {
         // In production, get layout from entry-server bundle
         // Vite bundles everything into entry-server.mjs, so we can't import separate files
@@ -249,17 +258,22 @@ export class RenderService {
             this.rootLayout = entryModule.getRootLayout();
             if (this.rootLayout) {
               this.logger.log(`✓ Loaded root layout from entry-server bundle`);
+              this.rootLayoutChecked = true;
               return this.rootLayout;
             }
           }
         }
       }
 
+      this.rootLayoutChecked = true;
       this.rootLayout = null;
       return null;
     } catch (error: any) {
       this.logger.warn(`⚠️  Error loading root layout: ${error.message}`);
+      this.rootLayoutChecked = true;
       this.rootLayout = null;
+      // Re-discover next time in development (e.g. the file was removed)
+      this.rootLayoutDevPath = null;
       return null;
     }
   }
@@ -276,25 +290,20 @@ export class RenderService {
    * - Writes directly to response
    * - Better TTFB, progressive rendering
    * - Requires response object
+   *
+   * @param nonce - Optional CSP nonce applied to injected script tags
    */
   async render(
     viewComponent: any,
     data: any = {},
     res?: SSRResponse,
     head?: HeadData,
+    nonce?: string,
   ): Promise<string | void> {
     // Merge default head with page-specific head
     const mergedHead = this.mergeHead(this.defaultHead, head);
 
-    // Build render context for renderers
-    const renderContext = {
-      template: this.template,
-      vite: this.vite,
-      manifest: this.manifest,
-      serverManifest: this.serverManifest,
-      entryServerPath: this.entryServerPath,
-      isDevelopment: this.isDevelopment,
-    };
+    const renderContext = this.buildRendererContext(nonce);
 
     if (this.ssrMode === 'stream') {
       if (!res) {
@@ -331,22 +340,28 @@ export class RenderService {
   ): Promise<SegmentResponse> {
     const mergedHead = this.mergeHead(this.defaultHead, head);
 
-    const renderContext = {
+    return this.stringRenderer.renderSegment(
+      viewComponent,
+      data,
+      this.buildRendererContext(),
+      swapTarget,
+      mergedHead,
+    );
+  }
+
+  /**
+   * Snapshot of everything renderers need for one render pass
+   */
+  private buildRendererContext(nonce?: string): RendererContext {
+    return {
       template: this.template,
       vite: this.vite,
       manifest: this.manifest,
       serverManifest: this.serverManifest,
       entryServerPath: this.entryServerPath,
       isDevelopment: this.isDevelopment,
+      nonce,
     };
-
-    return this.stringRenderer.renderSegment(
-      viewComponent,
-      data,
-      renderContext,
-      swapTarget,
-      mergedHead,
-    );
   }
 
   /**

--- a/packages/react/src/render/renderers/stream-renderer.ts
+++ b/packages/react/src/render/renderers/stream-renderer.ts
@@ -1,28 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type { ViteDevServer } from 'vite';
 import type { HeadData, SSRResponse } from '../../interfaces';
 import { TemplateParserService } from '../template-parser.service';
 import { StreamingErrorHandler } from '../streaming-error-handler';
 import { getRawResponse } from '../adapters';
+import {
+  loadServerModule,
+  type RendererContext,
+} from '../server-module-loader';
+import { getComponentName } from '../component-name.util';
+import { injectPlaceholder } from '../template.util';
 
-interface ViteManifest {
-  [key: string]: {
-    file: string;
-    src?: string;
-    isEntry?: boolean;
-    imports?: string[];
-    css?: string[];
-  };
-}
-
-export interface StreamRenderContext {
-  template: string;
-  vite: ViteDevServer | null;
-  manifest: ViteManifest | null;
-  serverManifest: ViteManifest | null;
-  entryServerPath: string;
-  isDevelopment: boolean;
-}
+export type StreamRenderContext = RendererContext;
 
 /**
  * Streaming SSR renderer using React's renderToPipeableStream
@@ -84,37 +72,7 @@ export class StreamRenderer {
         // Parse template into parts
         const templateParts = this.templateParser.parseTemplate(template);
 
-        // Import and use the SSR render function
-        let renderModule;
-        if (context.vite) {
-          // Development: Use Vite's SSR loading with HMR support from package template
-          renderModule = await context.vite.ssrLoadModule(
-            context.entryServerPath,
-          );
-        } else {
-          // Production: Import the built server bundle using manifest
-          if (context.serverManifest) {
-            // Find the entry file in the manifest (supports both old and new paths)
-            const manifestEntry = Object.entries(context.serverManifest).find(
-              ([key, value]: [string, any]) =>
-                value.isEntry && key.includes('entry-server'),
-            );
-
-            if (manifestEntry) {
-              const [, entry] = manifestEntry;
-              const serverPath = `${process.cwd()}/dist/server/${entry.file}`;
-              renderModule = await import(serverPath);
-            } else {
-              throw new Error(
-                'Server bundle not found in manifest. Run `pnpm build:server` to generate the server bundle.',
-              );
-            }
-          } else {
-            throw new Error(
-              'Server bundle not found in manifest. Run `pnpm build:server` to generate the server bundle.',
-            );
-          }
-        }
+        const renderModule = await loadServerModule(context);
 
         // Extract data, context, and layouts
         const {
@@ -123,9 +81,7 @@ export class StreamRenderer {
           __layouts: layouts,
         } = data;
 
-        // Get component name for client-side hydration and logging
-        const componentName =
-          viewComponent.displayName || viewComponent.name || 'Component';
+        const componentName = getComponentName(viewComponent);
 
         // Build inline scripts (including layout metadata)
         const inlineScripts = this.templateParser.buildInlineScripts(
@@ -133,22 +89,51 @@ export class StreamRenderer {
           pageContext,
           componentName,
           layouts,
+          context.nonce,
         );
 
-        // Get client script tag
+        // Assets come from the Vite dev server whenever one is attached;
+        // otherwise from the production manifest
+        const useDevAssets = context.vite !== null;
         const clientScript = this.templateParser.getClientScriptTag(
-          context.isDevelopment,
+          useDevAssets,
           context.manifest,
+          context.nonce,
         );
 
-        // Get stylesheet tags
         const stylesheetTags = this.templateParser.getStylesheetTags(
-          context.isDevelopment,
+          useDevAssets,
           context.manifest,
         );
 
         // Generate head tags
         const headTags = this.templateParser.buildHeadTags(head);
+
+        // Build the closing chunk now so the 'end' handler stays simple.
+        // Hydration scripts belong OUTSIDE the root div (matching string mode
+        // and the template placeholders); writing them inside #root would
+        // make them part of the hydrated tree.
+        let closingChunk = templateParts.rootEnd;
+        let htmlEnd = templateParts.htmlEnd;
+        if (htmlEnd.includes('<!--initial-state-->')) {
+          htmlEnd = injectPlaceholder(
+            htmlEnd,
+            '<!--initial-state-->',
+            inlineScripts,
+          );
+        } else {
+          closingChunk += inlineScripts;
+        }
+        if (htmlEnd.includes('<!--client-scripts-->')) {
+          htmlEnd = injectPlaceholder(
+            htmlEnd,
+            '<!--client-scripts-->',
+            clientScript,
+          );
+        } else {
+          closingChunk += clientScript;
+        }
+        closingChunk += htmlEnd;
 
         // Set up streaming with error handlers
         let didError = false;
@@ -178,8 +163,16 @@ export class StreamRenderer {
 
               // Write HTML start with styles and head meta injected
               let htmlStart = templateParts.htmlStart;
-              htmlStart = htmlStart.replace('<!--styles-->', stylesheetTags);
-              htmlStart = htmlStart.replace('<!--head-meta-->', headTags);
+              htmlStart = injectPlaceholder(
+                htmlStart,
+                '<!--styles-->',
+                stylesheetTags,
+              );
+              htmlStart = injectPlaceholder(
+                htmlStart,
+                '<!--head-meta-->',
+                headTags,
+              );
               rawRes.write(htmlStart);
 
               // Write root div start
@@ -240,19 +233,8 @@ export class StreamRenderer {
             return;
           }
 
-          // Write inline scripts
-          rawRes.write(inlineScripts);
-
-          // Write client script
-          rawRes.write(clientScript);
-
-          // Write root div end
-          rawRes.write(templateParts.rootEnd);
-
-          // Write HTML end
-          rawRes.write(templateParts.htmlEnd);
-
-          // End the response
+          // Close the root div, then hydration scripts and closing tags
+          rawRes.write(closingChunk);
           rawRes.end();
 
           // Log completion
@@ -287,14 +269,10 @@ export class StreamRenderer {
       // Execute the async function and handle errors
       executeStream().catch((error) => {
         // Handle error before streaming started
-        const componentName =
-          typeof viewComponent === 'function'
-            ? viewComponent.name
-            : String(viewComponent);
         this.streamingErrorHandler.handleShellError(
           error as Error,
           res,
-          componentName,
+          getComponentName(viewComponent),
           context.isDevelopment,
         );
         // Resolve after handling error

--- a/packages/react/src/render/renderers/string-renderer.ts
+++ b/packages/react/src/render/renderers/string-renderer.ts
@@ -1,27 +1,17 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { uneval } from 'devalue';
-import type { ViteDevServer } from 'vite';
 import type { HeadData, SegmentResponse } from '../../interfaces';
 import { TemplateParserService } from '../template-parser.service';
+import {
+  loadServerModule,
+  type RendererContext,
+} from '../server-module-loader';
+import {
+  getComponentName,
+  serializeLayoutMetadata,
+} from '../component-name.util';
+import { injectPlaceholder } from '../template.util';
 
-interface ViteManifest {
-  [key: string]: {
-    file: string;
-    src?: string;
-    isEntry?: boolean;
-    imports?: string[];
-    css?: string[];
-  };
-}
-
-export interface StringRenderContext {
-  template: string;
-  vite: ViteDevServer | null;
-  manifest: ViteManifest | null;
-  serverManifest: ViteManifest | null;
-  entryServerPath: string;
-  isDevelopment: boolean;
-}
+export type StringRenderContext = RendererContext;
 
 /**
  * String-based SSR renderer using React's renderToString
@@ -56,120 +46,52 @@ export class StringRenderer {
       template = await context.vite.transformIndexHtml('/', template);
     }
 
-    // Import and use the SSR render function
-    let renderModule;
-    if (context.vite) {
-      // Development: Use Vite's SSR loading with HMR support from package template
-      renderModule = await context.vite.ssrLoadModule(context.entryServerPath);
-    } else {
-      // Production: Import the built server bundle using manifest
-      if (context.serverManifest) {
-        // Find the entry file in the manifest (supports both old and new paths)
-        const manifestEntry = Object.entries(context.serverManifest).find(
-          ([key, value]: [string, any]) =>
-            value.isEntry && key.includes('entry-server'),
-        );
+    const renderModule = await loadServerModule(context);
 
-        if (manifestEntry) {
-          const [, entry] = manifestEntry;
-          const serverPath = `${process.cwd()}/dist/server/${entry.file}`;
-          renderModule = await import(serverPath);
-        } else {
-          throw new Error(
-            'Server bundle not found in manifest. Run `pnpm build:server` to generate the server bundle.',
-          );
-        }
-      } else {
-        throw new Error(
-          'Server bundle not found in manifest. Run `pnpm build:server` to generate the server bundle.',
-        );
-      }
-    }
-
-    // Extract data, context, and layouts
     const { data: pageData, __context: pageContext, __layouts: layouts } = data;
 
     // Render the React component (pass component directly)
     const appHtml = await renderModule.renderComponent(viewComponent, data);
 
-    // Get component name for client-side hydration
-    const componentName =
-      viewComponent.displayName || viewComponent.name || 'Component';
+    const componentName = getComponentName(viewComponent);
 
-    // Serialize layout metadata (names and props, not functions)
-    const layoutMetadata = layouts
-      ? layouts.map((l: any) => ({
-          name: l.layout.displayName || l.layout.name || 'Layout',
-          props: l.props,
-        }))
-      : [];
+    // Serialize initial state, context, and layouts for client hydration
+    const initialStateScript = this.templateParser.buildInlineScripts(
+      pageData,
+      pageContext,
+      componentName,
+      layouts,
+      context.nonce,
+    );
 
-    // Serialize initial state, context, and layouts for client
-    const initialStateScript = `
-        <script>
-          window.__INITIAL_STATE__ = ${uneval(pageData)};
-          window.__CONTEXT__ = ${uneval(pageContext)};
-          window.__COMPONENT_NAME__ = ${uneval(componentName)};
-          window.__LAYOUTS__ = ${uneval(layoutMetadata)};
-        </script>
-      `;
+    // Assets come from the Vite dev server whenever one is attached;
+    // otherwise from the production manifest
+    const useDevAssets = context.vite !== null;
+    const clientScript = this.templateParser.getClientScriptTag(
+      useDevAssets,
+      context.manifest,
+      context.nonce,
+    );
 
-    // Inject client script and styles
-    let clientScript = '';
-    let styles = '';
+    const styles = this.templateParser.getStylesheetTags(
+      useDevAssets,
+      context.manifest,
+    );
 
-    if (context.vite) {
-      // Development: Use app's local entry-client in views directory
-      clientScript = `<script type="module" src="/src/views/entry-client.tsx"></script>`;
-    } else {
-      // Production: Use manifest to get hashed filename
-      if (context.manifest) {
-        // Find the entry file in the manifest (supports both old and new paths)
-        const manifestEntry = Object.entries(context.manifest).find(
-          ([key, value]: [string, any]) =>
-            value.isEntry && key.includes('entry-client'),
-        );
-
-        if (manifestEntry) {
-          const [, entry] = manifestEntry;
-          const entryFile = entry.file;
-          clientScript = `<script type="module" src="/${entryFile}"></script>`;
-
-          // Inject CSS from manifest
-          if (entry.css) {
-            const cssFiles = entry.css;
-            styles = cssFiles
-              .map((css) => `<link rel="stylesheet" href="/${css}" />`)
-              .join('\n    ');
-          }
-        } else {
-          this.logger.error('⚠️  Client entry not found in manifest');
-          clientScript = `<script type="module" src="/assets/client.js"></script>`;
-        }
-      } else {
-        this.logger.error('⚠️  Client manifest not found');
-        clientScript = `<script type="module" src="/assets/client.js"></script>`;
-      }
-    }
-
-    // Generate head tags
     const headTags = this.templateParser.buildHeadTags(head);
 
-    // Replace placeholders
-    let html = template.replace('<!--app-html-->', appHtml);
-    html = html.replace('<!--initial-state-->', initialStateScript);
-    html = html.replace('<!--client-scripts-->', clientScript);
-    html = html.replace('<!--styles-->', styles);
-    html = html.replace('<!--head-meta-->', headTags);
+    let html = injectPlaceholder(template, '<!--app-html-->', appHtml);
+    html = injectPlaceholder(html, '<!--initial-state-->', initialStateScript);
+    html = injectPlaceholder(html, '<!--client-scripts-->', clientScript);
+    html = injectPlaceholder(html, '<!--styles-->', styles);
+    html = injectPlaceholder(html, '<!--head-meta-->', headTags);
 
     // Log performance metrics in development
     if (context.isDevelopment) {
       const duration = Date.now() - startTime;
-      const name =
-        typeof viewComponent === 'function'
-          ? viewComponent.name
-          : String(viewComponent);
-      this.logger.log(`[SSR] ${name} rendered in ${duration}ms (string mode)`);
+      this.logger.log(
+        `[SSR] ${componentName} rendered in ${duration}ms (string mode)`,
+      );
     }
 
     return html;
@@ -188,32 +110,7 @@ export class StringRenderer {
   ): Promise<SegmentResponse> {
     const startTime = Date.now();
 
-    // Import the SSR render function
-    let renderModule;
-    if (context.vite) {
-      renderModule = await context.vite.ssrLoadModule(context.entryServerPath);
-    } else {
-      if (context.serverManifest) {
-        const manifestEntry = Object.entries(context.serverManifest).find(
-          ([key, value]: [string, any]) =>
-            value.isEntry && key.includes('entry-server'),
-        );
-
-        if (manifestEntry) {
-          const [, entry] = manifestEntry;
-          const serverPath = `${process.cwd()}/dist/server/${entry.file}`;
-          renderModule = await import(serverPath);
-        } else {
-          throw new Error(
-            'Server bundle not found in manifest. Run `pnpm build:server` to generate the server bundle.',
-          );
-        }
-      } else {
-        throw new Error(
-          'Server bundle not found in manifest. Run `pnpm build:server` to generate the server bundle.',
-        );
-      }
-    }
+    const renderModule = await loadServerModule(context);
 
     // Extract page data, context, and layouts (filtered to those below swap target)
     const { data: pageData, __context: pageContext, __layouts: layouts } = data;
@@ -221,17 +118,8 @@ export class StringRenderer {
     // Render the segment with its layouts (layouts below swap target)
     const html = await renderModule.renderSegment(viewComponent, data);
 
-    // Get component name for client-side hydration
-    const componentName =
-      viewComponent.displayName || viewComponent.name || 'Component';
-
-    // Serialize layout metadata for client-side hydration
-    const layoutMetadata = layouts
-      ? layouts.map((l: any) => ({
-          name: l.layout.displayName || l.layout.name || 'Layout',
-          props: l.props,
-        }))
-      : [];
+    const componentName = getComponentName(viewComponent);
+    const layoutMetadata = serializeLayoutMetadata(layouts);
 
     // Log performance metrics in development
     if (context.isDevelopment) {

--- a/packages/react/src/render/renderers/string-renderer.ts
+++ b/packages/react/src/render/renderers/string-renderer.ts
@@ -99,7 +99,7 @@ export class StringRenderer {
     // Serialize layout metadata (names and props, not functions)
     const layoutMetadata = layouts
       ? layouts.map((l: any) => ({
-          name: l.layout.displayName || l.layout.name || 'default',
+          name: l.layout.displayName || l.layout.name || 'Layout',
           props: l.props,
         }))
       : [];
@@ -228,7 +228,7 @@ export class StringRenderer {
     // Serialize layout metadata for client-side hydration
     const layoutMetadata = layouts
       ? layouts.map((l: any) => ({
-          name: l.layout.displayName || l.layout.name || 'default',
+          name: l.layout.displayName || l.layout.name || 'Layout',
           props: l.props,
         }))
       : [];

--- a/packages/react/src/render/server-module-loader.ts
+++ b/packages/react/src/render/server-module-loader.ts
@@ -1,0 +1,70 @@
+import type { ViteDevServer } from 'vite';
+
+export interface ViteManifest {
+  [key: string]: {
+    file: string;
+    src?: string;
+    isEntry?: boolean;
+    imports?: string[];
+    css?: string[];
+  };
+}
+
+/**
+ * Everything a renderer needs to produce HTML, assembled once per request
+ * by RenderService and shared by both rendering modes.
+ */
+export interface RendererContext {
+  template: string;
+  vite: ViteDevServer | null;
+  manifest: ViteManifest | null;
+  serverManifest: ViteManifest | null;
+  entryServerPath: string;
+  isDevelopment: boolean;
+  /** CSP nonce for injected script tags, when the app provides one */
+  nonce?: string;
+}
+
+/**
+ * The entry-server module shape produced by the user's entry-server.tsx
+ */
+export interface ServerEntryModule {
+  renderComponent: (component: any, data: any) => Promise<string> | string;
+  renderSegment: (component: any, data: any) => Promise<string> | string;
+  renderComponentStream: (
+    component: any,
+    data: any,
+    callbacks?: Record<string, (...args: any[]) => void>,
+  ) => { pipe: (destination: any) => void; abort: () => void };
+  getRootLayout?: () => any;
+}
+
+const SERVER_BUNDLE_ERROR =
+  'Server bundle not found in manifest. Run `pnpm build:server` to generate the server bundle.';
+
+/**
+ * Load the entry-server module.
+ *
+ * Development: through Vite's SSR module loader (HMR-aware).
+ * Production: from the built server bundle, resolved via the Vite manifest.
+ */
+export async function loadServerModule(
+  context: Pick<RendererContext, 'vite' | 'serverManifest' | 'entryServerPath'>,
+): Promise<ServerEntryModule> {
+  if (context.vite) {
+    return (await context.vite.ssrLoadModule(
+      context.entryServerPath,
+    )) as ServerEntryModule;
+  }
+
+  const manifestEntry = Object.entries(context.serverManifest ?? {}).find(
+    ([key, value]) => value.isEntry && key.includes('entry-server'),
+  );
+
+  if (!manifestEntry) {
+    throw new Error(SERVER_BUNDLE_ERROR);
+  }
+
+  const serverPath = `${process.cwd()}/dist/server/${manifestEntry[1].file}`;
+  return (await import(serverPath)) as ServerEntryModule;
+}

--- a/packages/react/src/render/template-parser.service.ts
+++ b/packages/react/src/render/template-parser.service.ts
@@ -1,13 +1,35 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { uneval } from 'devalue';
 import escapeHtml from 'escape-html';
 import type { TemplateParts, HeadData } from '../interfaces';
+import { serializeLayoutMetadata } from './component-name.util';
+
+/**
+ * Valid HTML attribute names for custom head tags.
+ * Restrictive on purpose: attribute names are interpolated into markup raw,
+ * so anything outside this set is rejected to prevent markup injection.
+ */
+const VALID_ATTRIBUTE_NAME = /^[a-zA-Z][a-zA-Z0-9:_-]*$/;
+
+interface ViteManifestEntry {
+  file: string;
+  src?: string;
+  isEntry?: boolean;
+  imports?: string[];
+  css?: string[];
+}
+
+interface ViteManifest {
+  [key: string]: ViteManifestEntry;
+}
 
 /**
  * Service for parsing HTML templates and building inline scripts for SSR
  */
 @Injectable()
 export class TemplateParserService {
+  private readonly logger = new Logger(TemplateParserService.name);
+
   // Mapping of HeadData fields to their HTML tag renderers
   // Order matters: title and description first for SEO best practices
   private readonly headTagRenderers = [
@@ -45,6 +67,7 @@ export class TemplateParserService {
         `<meta property="og:image" content="${escapeHtml(v)}" />`,
     },
   ];
+
   /**
    * Parse HTML template into parts for streaming SSR
    *
@@ -99,24 +122,23 @@ export class TemplateParserService {
    * Safely serializes data using devalue to avoid XSS vulnerabilities.
    * Devalue is designed specifically for SSR, handling complex types safely
    * while being faster and more secure than alternatives.
+   *
+   * @param nonce - Optional CSP nonce added to the script tag so the inline
+   *   script can run under a strict Content-Security-Policy.
    */
   buildInlineScripts(
     data: any,
     context: any,
     componentName: string,
     layouts?: Array<{ layout: any; props?: any }>,
+    nonce?: string,
   ): string {
     // Serialize layout metadata (names and props, not functions)
-    const layoutMetadata = layouts
-      ? layouts.map((l) => ({
-          name: l.layout.displayName || l.layout.name || 'default',
-          props: l.props,
-        }))
-      : [];
+    const layoutMetadata = serializeLayoutMetadata(layouts);
 
     // Use devalue for consistent, secure serialization
     // Same approach used in string mode for consistency across rendering modes
-    return `<script>
+    return `<script${this.nonceAttribute(nonce)}>
 window.__INITIAL_STATE__ = ${uneval(data)};
 window.__CONTEXT__ = ${uneval(context)};
 window.__COMPONENT_NAME__ = ${uneval(componentName)};
@@ -130,18 +152,23 @@ window.__LAYOUTS__ = ${uneval(layoutMetadata)};
    * In development: Direct module import with Vite HMR
    * In production: Hashed filename from manifest
    */
-  getClientScriptTag(isDevelopment: boolean, manifest?: any): string {
+  getClientScriptTag(
+    isDevelopment: boolean,
+    manifest?: ViteManifest | null,
+    nonce?: string,
+  ): string {
+    const nonceAttr = this.nonceAttribute(nonce);
+
     if (isDevelopment) {
-      return '<script type="module" src="/src/views/entry-client.tsx"></script>';
+      return `<script type="module"${nonceAttr} src="/src/views/entry-client.tsx"></script>`;
     }
 
-    // Look for entry-client in manifest
-    if (!manifest || !manifest['src/views/entry-client.tsx']) {
+    const entry = this.findClientEntry(manifest);
+    if (!entry) {
       throw new Error('Manifest missing entry for src/views/entry-client.tsx');
     }
 
-    const entryFile = manifest['src/views/entry-client.tsx'].file;
-    return `<script type="module" src="/${entryFile}"></script>`;
+    return `<script type="module"${nonceAttr} src="/${entry.file}"></script>`;
   }
 
   /**
@@ -150,17 +177,16 @@ window.__LAYOUTS__ = ${uneval(layoutMetadata)};
    * In development: Direct link to source CSS file
    * In production: Hashed CSS files from manifest
    */
-  getStylesheetTags(isDevelopment: boolean, manifest?: any): string {
+  getStylesheetTags(
+    isDevelopment: boolean,
+    manifest?: ViteManifest | null,
+  ): string {
     if (isDevelopment) {
       return '';
     }
 
-    if (!manifest || !manifest['src/views/entry-client.tsx']) {
-      return '';
-    }
-
-    const entry = manifest['src/views/entry-client.tsx'];
-    if (!entry.css || entry.css.length === 0) {
+    const entry = this.findClientEntry(manifest);
+    if (!entry?.css?.length) {
       return '';
     }
 
@@ -204,10 +230,50 @@ window.__LAYOUTS__ = ${uneval(layoutMetadata)};
   }
 
   /**
-   * Build an HTML tag from an object of attributes
+   * Locate the client entry in the Vite manifest.
+   *
+   * Single source of truth for both rendering modes: prefer any entry chunk
+   * whose key contains "entry-client" (covers custom project layouts), then
+   * fall back to the conventional exact key.
+   */
+  private findClientEntry(
+    manifest?: ViteManifest | null,
+  ): ViteManifestEntry | null {
+    if (!manifest) {
+      return null;
+    }
+
+    const entryChunk = Object.entries(manifest).find(
+      ([key, value]) => value.isEntry && key.includes('entry-client'),
+    );
+    if (entryChunk) {
+      return entryChunk[1];
+    }
+
+    return manifest['src/views/entry-client.tsx'] ?? null;
+  }
+
+  private nonceAttribute(nonce?: string): string {
+    return nonce ? ` nonce="${escapeHtml(nonce)}"` : '';
+  }
+
+  /**
+   * Build an HTML tag from an object of attributes.
+   *
+   * Attribute values are HTML-escaped; attribute names cannot be escaped, so
+   * names that are not valid HTML attribute identifiers are rejected.
    */
   private buildTag(tagName: string, attrs: Record<string, any>): string {
     const attrString = Object.entries(attrs)
+      .filter(([key]) => {
+        if (VALID_ATTRIBUTE_NAME.test(key)) {
+          return true;
+        }
+        this.logger.warn(
+          `Skipping invalid attribute name "${key}" on <${tagName}> head tag`,
+        );
+        return false;
+      })
       .map(([key, value]) => `${key}="${escapeHtml(String(value))}"`)
       .join(' ');
     return `<${tagName} ${attrString} />`;

--- a/packages/react/src/render/template.util.ts
+++ b/packages/react/src/render/template.util.ts
@@ -1,0 +1,18 @@
+/**
+ * Replace a template placeholder with content.
+ *
+ * Uses a replacer function instead of a replacement string: String.replace
+ * interprets `$&`, `$'` etc. in replacement strings, which would let
+ * user-influenced content (serialized state, rendered HTML) splice template
+ * fragments into the output.
+ *
+ * Shared by both renderers so the placeholder-injection semantics cannot
+ * drift between string and stream mode.
+ */
+export function injectPlaceholder(
+  html: string,
+  placeholder: string,
+  content: string,
+): string {
+  return html.replace(placeholder, () => content);
+}

--- a/packages/react/src/render/vite-initializer.service.ts
+++ b/packages/react/src/render/vite-initializer.service.ts
@@ -13,6 +13,7 @@ import { RenderService } from './render.service';
 import type { ViteConfig } from '../interfaces';
 import type { ViteDevServer } from 'vite';
 import { detectAdapterType } from './adapters';
+import { isDevelopmentEnv, warnIfNodeEnvUnset } from './environment.util';
 
 /**
  * Automatically initializes Vite in development or static assets in production
@@ -40,10 +41,6 @@ export class ViteInitializerService
     @Optional() @Inject('VITE_CONFIG') viteConfig?: ViteConfig,
   ) {
     this.vitePort = viteConfig?.port || 5173;
-
-    // Register signal handlers for cleanup when lifecycle hooks may not fire
-    // This handles cases where enableShutdownHooks() wasn't called
-    this.registerSignalHandlers();
   }
 
   private registerSignalHandlers() {
@@ -59,9 +56,15 @@ export class ViteInitializerService
   }
 
   async onModuleInit() {
-    const isDevelopment = process.env.NODE_ENV !== 'production';
+    // Register signal handlers for cleanup when lifecycle hooks may not fire
+    // This handles cases where enableShutdownHooks() wasn't called.
+    // Registered here rather than in the constructor so plain instantiation
+    // (tests, DI graph construction) has no process-level side effects.
+    this.registerSignalHandlers();
 
-    if (isDevelopment) {
+    warnIfNodeEnvUnset(this.logger);
+
+    if (isDevelopmentEnv()) {
       await this.setupDevelopmentMode();
     } else {
       await this.setupProductionMode();

--- a/packages/react/test/cli-init/fixtures/.gitignore
+++ b/packages/react/test/cli-init/fixtures/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/react/test/cli-init/smoke.ts
+++ b/packages/react/test/cli-init/smoke.ts
@@ -1,0 +1,373 @@
+import { execFileSync, spawn, type ChildProcess } from 'child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { chromium, type Browser } from '@playwright/test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const PACKAGE_ROOT = join(__dirname, '../..');
+const REPO_ROOT = join(PACKAGE_ROOT, '../..');
+const FIXTURES_DIR = join(__dirname, 'fixtures');
+const APP_NAME = 'cli-init-smoke-app';
+const APP_DIR = join(FIXTURES_DIR, APP_NAME);
+const ROOT_LOCKFILE = join(REPO_ROOT, 'pnpm-lock.yaml');
+const NEST_PORT = Number(process.env.CLI_INIT_SMOKE_PORT ?? 3337);
+const VITE_PORT = Number(process.env.CLI_INIT_SMOKE_VITE_PORT ?? 5199);
+const KEEP_FIXTURE = process.env.KEEP_CLI_INIT_SMOKE === '1';
+
+function run(
+  command: string,
+  args: string[],
+  options: { cwd: string; env?: NodeJS.ProcessEnv },
+): void {
+  const display = [command, ...args].join(' ');
+  console.log(`$ ${display}`);
+  execFileSync(command, args, {
+    cwd: options.cwd,
+    stdio: 'inherit',
+    env: { ...process.env, ...options.env },
+  });
+}
+
+function cleanFixture(): void {
+  rmSync(APP_DIR, { recursive: true, force: true });
+  if (existsSync(FIXTURES_DIR)) {
+    for (const file of readdirSync(FIXTURES_DIR)) {
+      if (file.endsWith('.tgz')) {
+        rmSync(join(FIXTURES_DIR, file), { force: true });
+      }
+    }
+  }
+}
+
+function findPackedTarball(): string {
+  const tarball = readdirSync(FIXTURES_DIR).find(
+    (file) => file.startsWith('nestjs-ssr-react-') && file.endsWith('.tgz'),
+  );
+  if (!tarball) {
+    throw new Error('Could not find @nestjs-ssr/react tarball after pnpm pack');
+  }
+  return join(FIXTURES_DIR, tarball);
+}
+
+function readRootLockfile(): string | null {
+  return existsSync(ROOT_LOCKFILE)
+    ? readFileSync(ROOT_LOCKFILE, 'utf-8')
+    : null;
+}
+
+function writeSmokePage(): void {
+  writeFileSync(
+    join(APP_DIR, 'src/views/home.tsx'),
+    `import { useState } from 'react';
+import type { PageProps } from '@nestjs-ssr/react';
+
+interface HomeProps {
+  message: string;
+  initialCount: number;
+}
+
+export default function Home({
+  message,
+  initialCount,
+}: PageProps<HomeProps>) {
+  const [count, setCount] = useState(initialCount);
+
+  return (
+    <main data-testid="home-page">
+      <h1 data-testid="message">{message}</h1>
+      <p data-testid="count">{count}</p>
+      <button data-testid="increment" onClick={() => setCount((c) => c + 1)}>
+        Increment
+      </button>
+    </main>
+  );
+}
+`,
+  );
+
+  writeFileSync(
+    join(APP_DIR, 'src/app.controller.ts'),
+    `import { Controller, Get } from '@nestjs/common';
+import { Render, type RenderResponse } from '@nestjs-ssr/react';
+import Home from './views/home';
+
+interface HomeProps {
+  message: string;
+  initialCount: number;
+}
+
+@Controller()
+export class AppController {
+  @Get()
+  @Render(Home)
+  getHome(): RenderResponse<HomeProps> {
+    return {
+      props: {
+        message: 'CLI init smoke works',
+        initialCount: 2,
+      },
+      head: {
+        title: 'CLI Init Smoke',
+        description: 'Fresh Nest app initialized by @nestjs-ssr/react',
+      },
+    };
+  }
+}
+`,
+  );
+}
+
+function assertInitOutput(): void {
+  const packageJson = JSON.parse(
+    readFileSync(join(APP_DIR, 'package.json'), 'utf-8'),
+  ) as { scripts: Record<string, string> };
+  const tsconfig = JSON.parse(
+    readFileSync(join(APP_DIR, 'tsconfig.json'), 'utf-8'),
+  ) as { compilerOptions: Record<string, unknown>; exclude: string[] };
+  const appModule = readFileSync(join(APP_DIR, 'src/app.module.ts'), 'utf-8');
+  const main = readFileSync(join(APP_DIR, 'src/main.ts'), 'utf-8');
+  const template = readFileSync(join(APP_DIR, 'src/views/index.html'), 'utf-8');
+
+  if (!appModule.includes('RenderModule.forRoot')) {
+    throw new Error('init did not register RenderModule.forRoot');
+  }
+  if (!appModule.includes(`port: ${VITE_PORT}`)) {
+    throw new Error(
+      'init did not pass the requested Vite port to RenderModule',
+    );
+  }
+  if (!main.includes('app.enableShutdownHooks();')) {
+    throw new Error('init did not add app.enableShutdownHooks()');
+  }
+  if (!template.includes('<!--initial-state-->')) {
+    throw new Error('init did not copy the SSR HTML template');
+  }
+  if (tsconfig.compilerOptions.jsx !== 'react-jsx') {
+    throw new Error('init did not configure TSX support');
+  }
+  if (!tsconfig.exclude.includes('src/views/entry-client.tsx')) {
+    throw new Error('init did not exclude entry-client.tsx from TS build');
+  }
+  if (!packageJson.scripts.build?.includes('build:client')) {
+    throw new Error('init did not add the production build scripts');
+  }
+  if (!packageJson.scripts['dev:vite']?.includes(String(VITE_PORT))) {
+    throw new Error('init did not configure the requested Vite port');
+  }
+}
+
+async function waitForServer(
+  proc: ChildProcess,
+  url: string,
+  logs: string[],
+): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < 30000) {
+    if (proc.exitCode !== null) {
+      throw new Error(`Server exited before becoming ready.\n${logs.join('')}`);
+    }
+
+    try {
+      const response = await fetch(url);
+      if (response.status < 500) {
+        return;
+      }
+    } catch {
+      // Server is not ready yet.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`Server did not become ready at ${url}\n${logs.join('')}`);
+}
+
+function stopProcess(proc: ChildProcess): void {
+  if (!proc.pid || proc.exitCode !== null) {
+    return;
+  }
+
+  try {
+    process.kill(-proc.pid, 'SIGTERM');
+  } catch {
+    try {
+      proc.kill('SIGTERM');
+    } catch {
+      // Process already exited.
+    }
+  }
+}
+
+async function verifyRunningApp(): Promise<void> {
+  const logs: string[] = [];
+  const proc = spawn('node', ['dist/src/main.js'], {
+    cwd: APP_DIR,
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      PORT: String(NEST_PORT),
+    },
+  });
+
+  proc.stdout?.on('data', (chunk) => logs.push(chunk.toString()));
+  proc.stderr?.on('data', (chunk) => logs.push(chunk.toString()));
+
+  let browser: Browser | undefined;
+  try {
+    await waitForServer(proc, `http://localhost:${NEST_PORT}`, logs);
+
+    const response = await fetch(`http://localhost:${NEST_PORT}`);
+    const html = await response.text();
+    if (!html.includes('CLI init smoke works')) {
+      throw new Error('SSR HTML did not include controller data');
+    }
+    if (!html.includes('window.__INITIAL_STATE__')) {
+      throw new Error('SSR HTML did not include hydration state');
+    }
+    if (!html.includes('<title>CLI Init Smoke</title>')) {
+      throw new Error('SSR HTML did not include page head metadata');
+    }
+
+    browser = await chromium.launch();
+    const page = await browser.newPage();
+    const consoleMessages: string[] = [];
+    page.on('console', (message) => {
+      const text = message.text();
+      if (
+        message.type() === 'error' ||
+        text.toLowerCase().includes('hydration') ||
+        text.toLowerCase().includes('mismatch')
+      ) {
+        consoleMessages.push(text);
+      }
+    });
+
+    await page.goto(`http://localhost:${NEST_PORT}`);
+    await page.getByTestId('increment').click();
+    const count = await page.getByTestId('count').textContent();
+    if (count !== '3') {
+      throw new Error(`Expected hydrated counter to reach 3, got ${count}`);
+    }
+
+    const hydrationErrors = consoleMessages.filter((message) => {
+      const normalized = message.toLowerCase();
+      return (
+        normalized.includes('hydration') ||
+        normalized.includes('mismatch') ||
+        normalized.includes('did not match')
+      );
+    });
+    if (hydrationErrors.length > 0) {
+      throw new Error(
+        `Hydration warnings found:\n${hydrationErrors.join('\n')}`,
+      );
+    }
+  } finally {
+    await browser?.close();
+    stopProcess(proc);
+  }
+}
+
+async function main(): Promise<void> {
+  mkdirSync(FIXTURES_DIR, { recursive: true });
+  cleanFixture();
+  const rootLockfileBefore = readRootLockfile();
+  let scenarioError: unknown;
+
+  try {
+    run('pnpm', ['build'], { cwd: PACKAGE_ROOT });
+    run('pnpm', ['pack', '--pack-destination', FIXTURES_DIR], {
+      cwd: PACKAGE_ROOT,
+    });
+    const tarballPath = findPackedTarball();
+
+    run(
+      'pnpm',
+      [
+        'dlx',
+        '@nestjs/cli',
+        'new',
+        APP_NAME,
+        '--package-manager',
+        'pnpm',
+        '--skip-git',
+        '--skip-install',
+      ],
+      { cwd: FIXTURES_DIR },
+    );
+    writeFileSync(join(APP_DIR, 'pnpm-workspace.yaml'), 'packages:\n  - .\n');
+
+    run('pnpm', ['install'], { cwd: APP_DIR });
+    run('pnpm', ['add', tarballPath], { cwd: APP_DIR });
+    run(
+      'pnpm',
+      ['exec', 'nestjs-ssr', '--port', String(VITE_PORT), '--skip-install'],
+      { cwd: APP_DIR },
+    );
+
+    run(
+      'pnpm',
+      [
+        'add',
+        'react@^19.0.0',
+        'react-dom@^19.0.0',
+        'http-proxy-middleware@^3.0.0',
+      ],
+      { cwd: APP_DIR },
+    );
+    run(
+      'pnpm',
+      [
+        'add',
+        '-D',
+        'vite@^7.0.0',
+        '@vitejs/plugin-react@^4.0.0',
+        '@types/react@^19.0.0',
+        '@types/react-dom@^19.0.0',
+        'concurrently@^9.0.0',
+      ],
+      { cwd: APP_DIR },
+    );
+
+    assertInitOutput();
+    writeSmokePage();
+    run('pnpm', ['build'], { cwd: APP_DIR });
+    await verifyRunningApp();
+  } catch (error) {
+    scenarioError = error;
+  } finally {
+    if (!KEEP_FIXTURE) {
+      cleanFixture();
+    }
+  }
+
+  if (readRootLockfile() !== rootLockfileBefore) {
+    throw new Error(
+      'CLI init smoke test mutated the root pnpm-lock.yaml. ' +
+        'The generated fixture must stay isolated from the monorepo workspace.',
+    );
+  }
+
+  if (scenarioError) {
+    throw scenarioError;
+  }
+
+  console.log('CLI init smoke test passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
         '**/*.d.ts',
         'vitest.config.ts',
         'vitest.setup.ts',
-        'src/cli/**', // CLI is tested manually
         'src/templates/**', // Static HTML template
       ],
       // Coverage thresholds - current baseline


### PR DESCRIPTION
Security hardening pass over the render pipeline:

- Validate the client-controlled X-Current-Layouts header (bounded count,
  strict name shape) and add a clientNavigation config option to disable
  segment JSON responses entirely for apps that must not expose
  machine-readable page data
- Add CSP nonce support: a cspNonce factory in RenderModule config flows
  through to all injected script tags, enabling strict CSP without
  'unsafe-inline'
- Reject invalid attribute names in custom head link/meta tags - values
  were escaped but names were interpolated raw into markup
- Warn loudly (once) when NODE_ENV is unset, since the fail-open default
  enables the Vite dev proxy and stack-trace error pages in deployments
  that forgot to set it
- Centralize environment detection in environment.util.ts and layout/
  component naming in component-name.util.ts; root layout is now reloaded
  through Vite in development so layout edits are picked up without a
  restart (cached only in production)
- Register process signal handlers in onModuleInit instead of the
  constructor so instantiation has no process-level side effects
- Add "security" to the commitlint scope enum

https://claude.ai/code/session_015JyFXyr7Wq88xi8x9XfL45