### PR TITLE
feat(render): Add nest-cli.json SSR path resolution for monorepos

### DIFF
--- a/packages/react/src/__tests__/integration/monorepo-paths.integration.spec.ts
+++ b/packages/react/src/__tests__/integration/monorepo-paths.integration.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveNestSsrProjectPaths } from '../../config/nest-project-resolver';
+import { RenderModule } from '../../render/render.module';
+import { SSR_PROJECT_PATHS } from '../../config/nest-project-resolver';
+
+describe('Monorepo SSR path integration', () => {
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), 'nestjs-ssr-mono-int-'));
+
+    writeFileSync(
+      join(workspaceRoot, 'nest-cli.json'),
+      JSON.stringify(
+        {
+          monorepo: true,
+          root: 'apps/web',
+          projects: {
+            web: {
+              type: 'application',
+              root: 'apps/web',
+              sourceRoot: 'apps/web/src',
+              compilerOptions: {
+                tsConfigPath: 'apps/web/tsconfig.app.json',
+              },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    mkdirSync(join(workspaceRoot, 'apps/web'), { recursive: true });
+    writeFileSync(
+      join(workspaceRoot, 'apps/web/tsconfig.app.json'),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            outDir: '../../dist/apps/web',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    mkdirSync(join(workspaceRoot, 'apps/web/src/views'), { recursive: true });
+    writeFileSync(
+      join(workspaceRoot, 'apps/web/src/views/index.html'),
+      '<!DOCTYPE html><html><body><div id="root"><!--app-html--></div></body></html>',
+    );
+    writeFileSync(
+      join(workspaceRoot, 'apps/web/src/views/entry-server.tsx'),
+      'export function renderComponent() { return ""; }',
+    );
+  });
+
+  afterEach(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+    delete process.env.NEST_SSR_PROJECT;
+  });
+
+  it('resolves monorepo runtime paths for an active application', () => {
+    const paths = resolveNestSsrProjectPaths({
+      cwd: workspaceRoot,
+      project: 'web',
+    });
+
+    expect(paths.entryClientDev).toBe('/src/views/entry-client.tsx');
+    expect(paths.clientDistDir).toBe(
+      join(workspaceRoot, 'dist/apps/web/client'),
+    );
+    expect(paths.templateDev).toBe(
+      join(workspaceRoot, 'apps/web/src/views/index.html'),
+    );
+  });
+
+  it('wires monorepo project config into RenderModule providers', () => {
+    const previousCwd = process.cwd();
+    process.chdir(workspaceRoot);
+
+    try {
+      const dynamicModule = RenderModule.forRoot({ project: 'web' });
+      const pathsProvider = dynamicModule.providers?.find(
+        (provider) =>
+          typeof provider === 'object' &&
+          provider !== null &&
+          'provide' in provider &&
+          provider.provide === SSR_PROJECT_PATHS,
+      ) as { useValue?: { projectName: string; viewsDir: string } };
+
+      expect(pathsProvider?.useValue?.projectName).toBe('web');
+      expect(pathsProvider?.useValue?.viewsDir).toContain(
+        join('apps', 'web', 'src', 'views'),
+      );
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+});

--- a/packages/react/src/__tests__/integration/render-pipeline.integration.spec.ts
+++ b/packages/react/src/__tests__/integration/render-pipeline.integration.spec.ts
@@ -12,7 +12,12 @@ import { RenderInterceptor } from '../../render/render.interceptor';
 import { RenderService } from '../../render/render.service';
 import { TemplateParserService } from '../../render/template-parser.service';
 import { StreamingErrorHandler } from '../../render/streaming-error-handler';
+import { StringRenderer } from '../../render/renderers/string-renderer';
+import { StreamRenderer } from '../../render/renderers/stream-renderer';
+import { createDefaultTestProjectPaths } from '../../render/__tests__/test-project-paths';
 import { createElement } from 'react';
+
+const defaultProjectPaths = createDefaultTestProjectPaths('/project');
 
 describe('Render Pipeline Integration', () => {
   let renderInterceptor: RenderInterceptor;
@@ -24,20 +29,20 @@ describe('Render Pipeline Integration', () => {
 
   beforeEach(async () => {
     // Create service instances manually (faster than full module compilation)
-    const templateParser = new TemplateParserService();
+    const templateParser = new TemplateParserService(defaultProjectPaths);
     const errorHandler = new StreamingErrorHandler();
+    const stringRenderer = new StringRenderer(templateParser);
+    const streamRenderer = new StreamRenderer(templateParser, errorHandler);
 
-    // Create RenderService with dependencies
     renderService = new RenderService(
-      templateParser,
-      errorHandler,
-      'string', // SSR_MODE
+      stringRenderer,
+      streamRenderer,
+      defaultProjectPaths,
+      'string',
       {
-        // DEFAULT_HEAD
         title: 'Test App',
         description: 'Integration test app',
       },
-      undefined, // CUSTOM_TEMPLATE
     );
 
     reflector = new Reflector();

--- a/packages/react/src/cli/__tests__/init.spec.ts
+++ b/packages/react/src/cli/__tests__/init.spec.ts
@@ -158,6 +158,7 @@ export class AppModule {}
       views: string;
       'skip-install': boolean;
       port: string;
+      project: string;
     }> = {},
   ) {
     expect(cli.command).toBeTruthy();
@@ -241,8 +242,9 @@ export class AppModule {}
     expect(viteConfig).toContain('port: 4242');
     expect(viteConfig).toContain('hmr: { port: 4242 }');
     expect(viteConfig).toContain(
-      "client: resolve(process.cwd(), 'src/views/entry-client.tsx')",
+      "client: resolve(__dirname, 'src/views/entry-client.tsx')",
     );
+    expect(viteConfig).toContain('defineConfig(({ isSsrBuild })');
     expect(viteConfig).toContain("id.endsWith('.node')");
 
     const tsconfig = readJson<{
@@ -326,10 +328,10 @@ export class AppModule {}
     expect(packageJson.scripts).toMatchObject({
       build: 'nest build && pnpm build:client && pnpm build:server',
       'build:client':
-        'vite build --ssrManifest --outDir dist/client && cp src/views/index.html dist/client/index.html',
+        'vite build --config vite.config.ts --ssrManifest --outDir dist/client && cp src/views/index.html dist/client/index.html',
       'build:server':
-        'vite build --ssr src/views/entry-server.tsx --outDir dist/server',
-      'dev:vite': 'vite --port 4242',
+        'vite build --config vite.config.ts --ssr src/views/entry-server.tsx --outDir dist/server',
+      'dev:vite': 'vite --config vite.config.ts --port 4242',
       'dev:nest': 'nest start --watch --watchAssets --preserveWatchOutput',
     });
     expect(packageJson.scripts['start:dev']).toContain('concurrently --raw');
@@ -364,7 +366,7 @@ export class AppModule {}
 
     const viteConfig = read(projectDir, 'vite.config.ts');
     expect(viteConfig).toContain(
-      "client: resolve(process.cwd(), 'src/ui/pages/entry-client.tsx')",
+      "client: resolve(__dirname, 'src/ui/pages/entry-client.tsx')",
     );
 
     const packageJson = readJson<{ scripts: Record<string, string> }>(
@@ -375,7 +377,7 @@ export class AppModule {}
       'cp src/ui/pages/index.html dist/client/index.html',
     );
     expect(packageJson.scripts['build:server']).toContain(
-      'vite build --ssr src/ui/pages/entry-server.tsx --outDir dist/server',
+      'vite build --config vite.config.ts --ssr src/ui/pages/entry-server.tsx --outDir dist/server',
     );
 
     const appModule = read(projectDir, 'src/app.module.ts');
@@ -479,7 +481,7 @@ export class AppModule {}
     );
     expect(mockedConsola.log).toHaveBeenCalledWith('    port: 6060,');
     expect(mockedConsola.log).toHaveBeenCalledWith(
-      "      input: { client: resolve(process.cwd(), 'src/pages/entry-client.tsx') }",
+      "      input: { client: resolve(__dirname, 'src/pages/entry-client.tsx') }",
     );
 
     const packageJson = readJson<{ scripts: Record<string, string> }>(
@@ -490,8 +492,85 @@ export class AppModule {}
       'cp src/pages/index.html dist/client/index.html',
     );
     expect(packageJson.scripts['build:server']).toContain(
-      'vite build --ssr src/pages/entry-server.tsx --outDir dist/server',
+      'vite build --config vite.config.ts --ssr src/pages/entry-server.tsx --outDir dist/server',
     );
-    expect(packageJson.scripts['dev:vite']).toBe('vite --port 6060');
+    expect(packageJson.scripts['dev:vite']).toBe(
+      'vite --config vite.config.ts --port 6060',
+    );
+  });
+
+  it('scaffolds a monorepo application under apps/<project>', () => {
+    const projectDir = createProject({
+      nestCli: {
+        monorepo: true,
+        root: 'apps/web',
+        sourceRoot: 'apps/web/src',
+        projects: {
+          web: {
+            type: 'application',
+            root: 'apps/web',
+            sourceRoot: 'apps/web/src',
+            compilerOptions: {
+              tsConfigPath: 'apps/web/tsconfig.app.json',
+            },
+          },
+        },
+      },
+    });
+
+    mkdirSync(join(projectDir, 'apps/web/src'), { recursive: true });
+    writeJson(projectDir, 'apps/web/tsconfig.app.json', {
+      extends: '../../tsconfig.json',
+      compilerOptions: {
+        outDir: '../../dist/apps/web',
+      },
+      include: ['src/**/*'],
+      exclude: ['node_modules', 'dist'],
+    });
+    writeFileSync(
+      join(projectDir, 'apps/web/src/main.ts'),
+      `import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();`,
+    );
+    writeFileSync(
+      join(projectDir, 'apps/web/src/app.module.ts'),
+      `import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}
+`,
+    );
+
+    runInit(projectDir, { project: 'web', port: '5174' });
+
+    expect(
+      existsSync(join(projectDir, 'apps/web/src/views/entry-client.tsx')),
+    ).toBe(true);
+    expect(existsSync(join(projectDir, 'apps/web/vite.config.ts'))).toBe(true);
+
+    const appModule = read(projectDir, 'apps/web/src/app.module.ts');
+    expect(appModule).toContain(
+      "RenderModule.forRoot({ project: 'web', vite: { port: 5174 } })",
+    );
+
+    const packageJson = readJson<{ scripts: Record<string, string> }>(
+      projectDir,
+      'package.json',
+    );
+    expect(packageJson.scripts['dev:nest']).toContain('nest start web');
+    expect(packageJson.scripts['dev:vite']).toContain(
+      'vite --config apps/web/vite.config.ts',
+    );
+    expect(packageJson.scripts['start:dev']).toContain('NEST_SSR_PROJECT=web');
   });
 });

--- a/packages/react/src/cli/init-project-context.ts
+++ b/packages/react/src/cli/init-project-context.ts
@@ -1,0 +1,133 @@
+import { existsSync, readFileSync } from 'fs';
+import { join, relative } from 'path';
+import { resolveNestSsrProjectPaths } from '../config/nest-project-resolver.js';
+import type { NestSsrProjectPaths } from '../config/nest-project-paths.interface.js';
+
+interface NestCliProjectEntry {
+  type?: string;
+  root?: string;
+  sourceRoot?: string;
+  compilerOptions?: {
+    tsConfigPath?: string;
+  };
+}
+
+interface NestCliConfig {
+  monorepo?: boolean;
+  projects?: Record<string, NestCliProjectEntry>;
+}
+
+export interface InitProjectContext {
+  workspaceRoot: string;
+  projectName: string;
+  projectRoot: string;
+  sourceRoot: string;
+  viewsDirAbs: string;
+  viewsDirRel: string;
+  paths: NestSsrProjectPaths;
+  tsconfigPath: string;
+  tsconfigBuildPath: string;
+  viteConfigPath: string;
+  clientOutDirRel: string;
+  serverOutDirRel: string;
+  isMonorepo: boolean;
+}
+
+export function resolveInitProjectContext(options: {
+  cwd: string;
+  project?: string;
+  viewsDir?: string;
+}): InitProjectContext {
+  const workspaceRoot = options.cwd;
+  const nestCliPath = join(workspaceRoot, 'nest-cli.json');
+  const nestCli = existsSync(nestCliPath)
+    ? (JSON.parse(readFileSync(nestCliPath, 'utf-8')) as NestCliConfig)
+    : null;
+
+  const applicationProjects = Object.entries(nestCli?.projects ?? {}).filter(
+    ([, entry]) => entry.type === 'application' || !entry.type,
+  );
+  const isMonorepo = Boolean(
+    nestCli?.monorepo && applicationProjects.length > 0,
+  );
+
+  let projectName = options.project;
+  if (isMonorepo && applicationProjects.length > 1 && !projectName) {
+    throw new Error(
+      'Monorepo detected with multiple applications. Pass --project <name>.',
+    );
+  }
+
+  if (!projectName && applicationProjects.length === 1) {
+    projectName = applicationProjects[0][0];
+  }
+
+  const paths = resolveNestSsrProjectPaths({
+    cwd: workspaceRoot,
+    project: projectName,
+    viewsDir: options.viewsDir,
+  });
+
+  const projectEntry =
+    projectName && nestCli?.projects?.[projectName]
+      ? nestCli.projects[projectName]
+      : undefined;
+
+  const tsconfigPath = projectEntry?.compilerOptions?.tsConfigPath
+    ? join(workspaceRoot, projectEntry.compilerOptions.tsConfigPath)
+    : join(workspaceRoot, 'tsconfig.json');
+
+  const tsconfigBuildPath = existsSync(
+    join(workspaceRoot, 'tsconfig.build.json'),
+  )
+    ? join(workspaceRoot, 'tsconfig.build.json')
+    : isMonorepo
+      ? tsconfigPath
+      : join(workspaceRoot, 'tsconfig.build.json');
+
+  const viewsDirRel = relative(paths.projectRoot, paths.viewsDir).replace(
+    /\\/g,
+    '/',
+  );
+
+  return {
+    workspaceRoot,
+    projectName: paths.projectName,
+    projectRoot: paths.projectRoot,
+    sourceRoot: paths.sourceRoot,
+    viewsDirAbs: paths.viewsDir,
+    viewsDirRel,
+    paths,
+    tsconfigPath,
+    tsconfigBuildPath,
+    viteConfigPath: join(paths.projectRoot, 'vite.config.ts'),
+    clientOutDirRel: relative(paths.projectRoot, paths.clientDistDir).replace(
+      /\\/g,
+      '/',
+    ),
+    serverOutDirRel: relative(paths.projectRoot, paths.serverDistDir).replace(
+      /\\/g,
+      '/',
+    ),
+    isMonorepo,
+  };
+}
+
+export function buildRenderModuleConfig(
+  projectName: string,
+  vitePort: number,
+): string {
+  const configParts: string[] = [];
+  if (projectName !== 'default') {
+    configParts.push(`project: '${projectName}'`);
+  }
+  if (vitePort !== 5173) {
+    configParts.push(`vite: { port: ${vitePort} }`);
+  }
+
+  if (configParts.length === 0) {
+    return 'RenderModule.forRoot()';
+  }
+
+  return `RenderModule.forRoot({ ${configParts.join(', ')} })`;
+}

--- a/packages/react/src/cli/init.ts
+++ b/packages/react/src/cli/init.ts
@@ -7,12 +7,17 @@ import {
   mkdirSync,
   copyFileSync,
 } from 'fs';
-import { join, resolve, dirname } from 'path';
+import { join, resolve, dirname, relative } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { consola } from 'consola';
 import { defineCommand, runMain } from 'citty';
 import { configureNestCliForSwc, getSwcRcConfig } from './swc-support.js';
+import {
+  buildRenderModuleConfig,
+  resolveInitProjectContext,
+  type InitProjectContext,
+} from './init-project-context.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -44,13 +49,50 @@ const main = defineCommand({
       description: 'Vite dev server port',
       default: '5173',
     },
+    project: {
+      type: 'string',
+      description: 'Nest CLI project name (required for monorepos)',
+    },
   },
   run({ args }) {
     const cwd = process.cwd();
-    const viewsDir = args.views;
     const vitePort = parseInt(args.port, 10) || 5173;
     const packageJsonPath = join(cwd, 'package.json');
-    const tsconfigPath = join(cwd, 'tsconfig.json');
+
+    let initContext: InitProjectContext;
+    try {
+      initContext = resolveInitProjectContext({
+        cwd,
+        project: args.project,
+        viewsDir: args.views,
+      });
+    } catch (error) {
+      consola.error((error as Error).message);
+      process.exit(1);
+    }
+
+    const {
+      projectName,
+      projectRoot,
+      sourceRoot,
+      viewsDirAbs,
+      viewsDirRel,
+      tsconfigPath,
+      tsconfigBuildPath,
+      viteConfigPath,
+      clientOutDirRel,
+      serverOutDirRel,
+      isMonorepo,
+    } = initContext;
+    const viteConfigRel = relative(cwd, viteConfigPath).replace(/\\/g, '/');
+    const sourceDirRel = relative(projectRoot, sourceRoot).replace(/\\/g, '/');
+    const renderModuleConfig = buildRenderModuleConfig(projectName, vitePort);
+    const nestStartCommand =
+      projectName !== 'default'
+        ? `nest start ${projectName} --watch --watchAssets --preserveWatchOutput`
+        : 'nest start --watch --watchAssets --preserveWatchOutput';
+    const nestBuildCommand =
+      projectName !== 'default' ? `nest build ${projectName}` : 'nest build';
 
     consola.box('@nestjs-ssr/react initialization');
     consola.start('Setting up your NestJS SSR React project...\n');
@@ -93,7 +135,7 @@ const main = defineCommand({
       }
 
       // Check for main.ts
-      const mainTsPath = join(cwd, 'src/main.ts');
+      const mainTsPath = join(sourceRoot, 'main.ts');
       if (!existsSync(mainTsPath)) {
         consola.warn('No src/main.ts file found');
         consola.info(
@@ -130,53 +172,53 @@ const main = defineCommand({
     // 1. Copy entry-client.tsx to views directory
     consola.start('Creating entry-client.tsx...');
     const entryClientSrc = join(templateDir, 'entry-client.tsx');
-    const entryClientDest = join(cwd, viewsDir, 'entry-client.tsx');
+    const entryClientDest = join(viewsDirAbs, 'entry-client.tsx');
 
     // Create views directory if it doesn't exist
-    mkdirSync(join(cwd, viewsDir), { recursive: true });
+    mkdirSync(viewsDirAbs, { recursive: true });
 
     if (existsSync(entryClientDest) && !args.force) {
       consola.warn(
-        `${viewsDir}/entry-client.tsx already exists (use --force to overwrite)`,
+        `${viewsDirRel}/entry-client.tsx already exists (use --force to overwrite)`,
       );
     } else {
       copyFileSync(entryClientSrc, entryClientDest);
-      consola.success(`Created ${viewsDir}/entry-client.tsx`);
+      consola.success(`Created ${viewsDirRel}/entry-client.tsx`);
     }
 
     // 2. Copy entry-server.tsx to views directory
     consola.start('Creating entry-server.tsx...');
     const entryServerSrc = join(templateDir, 'entry-server.tsx');
-    const entryServerDest = join(cwd, viewsDir, 'entry-server.tsx');
+    const entryServerDest = join(viewsDirAbs, 'entry-server.tsx');
 
     if (existsSync(entryServerDest) && !args.force) {
       consola.warn(
-        `${viewsDir}/entry-server.tsx already exists (use --force to overwrite)`,
+        `${viewsDirRel}/entry-server.tsx already exists (use --force to overwrite)`,
       );
     } else {
       copyFileSync(entryServerSrc, entryServerDest);
-      consola.success(`Created ${viewsDir}/entry-server.tsx`);
+      consola.success(`Created ${viewsDirRel}/entry-server.tsx`);
     }
 
     // 3. Copy index.html template to views directory
     consola.start('Creating index.html...');
     const indexHtmlSrc = join(templateDir, 'index.html');
-    const indexHtmlDest = join(cwd, viewsDir, 'index.html');
+    const indexHtmlDest = join(viewsDirAbs, 'index.html');
 
     if (existsSync(indexHtmlDest) && !args.force) {
       consola.warn(
-        `${viewsDir}/index.html already exists (use --force to overwrite)`,
+        `${viewsDirRel}/index.html already exists (use --force to overwrite)`,
       );
     } else {
       copyFileSync(indexHtmlSrc, indexHtmlDest);
-      consola.success(`Created ${viewsDir}/index.html`);
+      consola.success(`Created ${viewsDirRel}/index.html`);
     }
 
     // 4. Update/create vite.config.ts
     consola.start('Configuring vite.config.ts...');
-    const viteConfigTs = join(cwd, 'vite.config.ts');
-    const viteConfigJs = join(cwd, 'vite.config.js');
-    const existingConfig = existsSync(viteConfigTs) || existsSync(viteConfigJs);
+    const viteConfigJs = join(projectRoot, 'vite.config.js');
+    const existingConfig =
+      existsSync(viteConfigPath) || existsSync(viteConfigJs);
 
     if (existingConfig) {
       consola.warn('vite.config already exists');
@@ -190,7 +232,7 @@ const main = defineCommand({
       consola.log('  build: {');
       consola.log('    rollupOptions: {');
       consola.log(
-        `      input: { client: resolve(process.cwd(), '${viewsDir}/entry-client.tsx') }`,
+        `      input: { client: resolve(__dirname, '${viewsDirRel}/entry-client.tsx') }`,
       );
       consola.log('    }');
       consola.log('  }');
@@ -199,12 +241,16 @@ const main = defineCommand({
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 
-export default defineConfig({
+export default defineConfig(({ isSsrBuild }) => ({
   plugins: [react({})],
   resolve: {
     alias: {
-      '@': resolve(process.cwd(), 'src'),
+      '@': resolve(__dirname, '${sourceDirRel}'),
     },
+    dedupe: ['react', 'react-dom', '@nestjs-ssr/react'],
+  },
+  ssr: {
+    noExternal: ['@nestjs-ssr/react'],
   },
   server: {
     port: ${vitePort},
@@ -212,19 +258,18 @@ export default defineConfig({
     hmr: { port: ${vitePort} },
   },
   build: {
-    outDir: 'dist/client',
+    outDir: isSsrBuild ? '${serverOutDirRel}' : '${clientOutDirRel}',
     manifest: true,
     rollupOptions: {
-      input: {
-        client: resolve(process.cwd(), '${viewsDir}/entry-client.tsx'),
-      },
-      // Externalize optional native dependencies that shouldn't be bundled for browser
+      input: !isSsrBuild
+        ? {
+            client: resolve(__dirname, '${viewsDirRel}/entry-client.tsx'),
+          }
+        : undefined,
       external: (id: string) => {
-        // Externalize fsevents - an optional macOS dependency
         if (id.includes('/fsevents') || id.endsWith('fsevents')) {
           return true;
         }
-        // Externalize .node native addon files
         if (id.endsWith('.node')) {
           return true;
         }
@@ -232,10 +277,10 @@ export default defineConfig({
       },
     },
   },
-});
+}));
 `;
-      writeFileSync(viteConfigTs, viteConfig);
-      consola.success('Created vite.config.ts');
+      writeFileSync(viteConfigPath, viteConfig);
+      consola.success(`Created ${relative(cwd, viteConfigPath)}`);
     }
 
     // 5. Update tsconfig.json
@@ -283,7 +328,8 @@ export default defineConfig({
         tsconfig.compilerOptions.paths = {};
       }
       if (!tsconfig.compilerOptions.paths['@/*']) {
-        tsconfig.compilerOptions.paths['@/*'] = ['./src/*'];
+        const aliasPath = `./${relative(dirname(tsconfigPath), sourceRoot).replace(/\\/g, '/')}/*`;
+        tsconfig.compilerOptions.paths['@/*'] = [aliasPath];
         updated = true;
       }
 
@@ -296,8 +342,8 @@ export default defineConfig({
         );
         if (!hasTsx) {
           // Add .tsx to includes if not present
-          if (!tsconfig.include.includes('src/**/*.tsx')) {
-            tsconfig.include.push('src/**/*.tsx');
+          if (!tsconfig.include.includes(`${sourceDirRel}/**/*.tsx`)) {
+            tsconfig.include.push(`${sourceDirRel}/**/*.tsx`);
             updated = true;
           }
         }
@@ -311,7 +357,7 @@ export default defineConfig({
         pattern.includes('entry-client.tsx'),
       );
       if (!hasEntryClientExclude) {
-        tsconfig.exclude.push(`${viewsDir}/entry-client.tsx`);
+        tsconfig.exclude.push(`${viewsDirRel}/entry-client.tsx`);
         updated = true;
       }
 
@@ -327,7 +373,6 @@ export default defineConfig({
 
     // 5.5. Update/create tsconfig.build.json
     consola.start('Configuring tsconfig.build.json...');
-    const tsconfigBuildPath = join(cwd, 'tsconfig.build.json');
     try {
       interface TsConfigBuild {
         extends?: string;
@@ -356,7 +401,7 @@ export default defineConfig({
       );
 
       if (!hasEntryClientExclude) {
-        tsconfigBuild.exclude.push(`${viewsDir}/entry-client.tsx`);
+        tsconfigBuild.exclude.push(`${viewsDirRel}/entry-client.tsx`);
         buildUpdated = true;
       }
 
@@ -437,7 +482,7 @@ export default defineConfig({
 
     // 6. Update main.ts with enableShutdownHooks
     consola.start('Configuring main.ts...');
-    const mainTsPath = join(cwd, 'src/main.ts');
+    const mainTsPath = join(sourceRoot, 'main.ts');
     try {
       if (existsSync(mainTsPath)) {
         let mainTs = readFileSync(mainTsPath, 'utf-8');
@@ -477,7 +522,7 @@ export default defineConfig({
 
     // 6.5. Register RenderModule in app.module.ts
     consola.start('Configuring app.module.ts...');
-    const appModulePath = join(cwd, 'src/app.module.ts');
+    const appModulePath = join(sourceRoot, 'app.module.ts');
     try {
       if (existsSync(appModulePath)) {
         let appModule = readFileSync(appModulePath, 'utf-8');
@@ -534,22 +579,19 @@ export default defineConfig({
           if (importsMatch) {
             const existingImports = importsMatch[2].trim();
             // Simple config - port defaults to 5173
-            const renderModuleConfig =
-              vitePort === 5173
-                ? 'RenderModule.forRoot()'
-                : `RenderModule.forRoot({ vite: { port: ${vitePort} } })`;
+            const renderModuleConfigLine = renderModuleConfig;
 
             if (existingImports === '') {
               // Empty imports array
               appModule = appModule.replace(
                 importsPattern,
-                `$1${renderModuleConfig}`,
+                `$1${renderModuleConfigLine}`,
               );
             } else {
               // Has existing imports - add at the end
               appModule = appModule.replace(
                 importsPattern,
-                `$1$2, ${renderModuleConfig}`,
+                `$1$2, ${renderModuleConfigLine}`,
               );
             }
             updated = true;
@@ -599,29 +641,33 @@ export default defineConfig({
 
       let shouldUpdate = false;
 
+      const buildClientScript = `vite build --config ${viteConfigRel} --ssrManifest --outDir ${clientOutDirRel} && cp ${viewsDirRel}/index.html ${clientOutDirRel}/index.html`;
+      const buildServerScript = `vite build --config ${viteConfigRel} --ssr ${viewsDirRel}/entry-server.tsx --outDir ${serverOutDirRel}`;
+      const devViteScript = `vite --config ${viteConfigRel} --port ${vitePort}`;
+      const startDevScript = isMonorepo
+        ? `NEST_SSR_PROJECT=${projectName} concurrently --raw -n vite,nest -c cyan,green "pnpm:dev:vite" "pnpm:dev:nest"`
+        : 'concurrently --raw -n vite,nest -c cyan,green "pnpm:dev:vite" "pnpm:dev:nest"';
+
       // Add build:client script if not present
       // Includes copying index.html to dist/client for production SSR
       if (!packageJson.scripts['build:client']) {
-        packageJson.scripts['build:client'] =
-          `vite build --ssrManifest --outDir dist/client && cp ${viewsDir}/index.html dist/client/index.html`;
+        packageJson.scripts['build:client'] = buildClientScript;
         shouldUpdate = true;
       }
 
       // Add build:server script if not present
       if (!packageJson.scripts['build:server']) {
-        packageJson.scripts['build:server'] =
-          `vite build --ssr ${viewsDir}/entry-server.tsx --outDir dist/server`;
+        packageJson.scripts['build:server'] = buildServerScript;
         shouldUpdate = true;
       }
 
       // Add dev scripts for running Vite and NestJS
       if (!packageJson.scripts['dev:vite']) {
-        packageJson.scripts['dev:vite'] = `vite --port ${vitePort}`;
+        packageJson.scripts['dev:vite'] = devViteScript;
         shouldUpdate = true;
       }
       if (!packageJson.scripts['dev:nest']) {
-        packageJson.scripts['dev:nest'] =
-          'nest start --watch --watchAssets --preserveWatchOutput';
+        packageJson.scripts['dev:nest'] = nestStartCommand;
         shouldUpdate = true;
       }
       // Update start:dev to use concurrently for better output
@@ -629,8 +675,7 @@ export default defineConfig({
         !packageJson.scripts['start:dev'] ||
         !packageJson.scripts['start:dev'].includes('concurrently')
       ) {
-        packageJson.scripts['start:dev'] =
-          'concurrently --raw -n vite,nest -c cyan,green "pnpm:dev:vite" "pnpm:dev:nest"';
+        packageJson.scripts['start:dev'] = startDevScript;
         shouldUpdate = true;
       }
 
@@ -638,8 +683,7 @@ export default defineConfig({
       // IMPORTANT: nest build runs FIRST because it has deleteOutDir: true
       // Then vite builds run to add client and server bundles
       const existingBuild = packageJson.scripts['build'];
-      const recommendedBuild =
-        'nest build && pnpm build:client && pnpm build:server';
+      const recommendedBuild = `${nestBuildCommand} && pnpm build:client && pnpm build:server`;
 
       if (!existingBuild) {
         // No build script exists, create one
@@ -769,7 +813,7 @@ export default defineConfig({
 
     consola.success('\nInitialization complete!');
     consola.box('Next steps');
-    consola.info(`1. Create your first view component in ${viewsDir}/`);
+    consola.info(`1. Create your first view component in ${viewsDirRel}/`);
     consola.info('2. Add a controller method with the @Render decorator:');
     consola.log('   import { Render } from "@nestjs-ssr/react";');
     consola.log('   @Get()');

--- a/packages/react/src/config/__tests__/nest-project-resolver.spec.ts
+++ b/packages/react/src/config/__tests__/nest-project-resolver.spec.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveNestSsrProjectPaths } from '../nest-project-resolver';
+
+describe('resolveNestSsrProjectPaths', () => {
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), 'nestjs-ssr-resolver-'));
+  });
+
+  afterEach(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+    delete process.env.NEST_SSR_PROJECT;
+  });
+
+  function writeJson(relativePath: string, data: unknown) {
+    const fullPath = join(workspaceRoot, relativePath);
+    mkdirSync(join(fullPath, '..'), { recursive: true });
+    writeFileSync(fullPath, JSON.stringify(data, null, 2));
+  }
+
+  it('resolves standard single-app paths', () => {
+    writeJson('nest-cli.json', {
+      sourceRoot: 'src',
+    });
+    mkdirSync(join(workspaceRoot, 'src/views'), { recursive: true });
+
+    const paths = resolveNestSsrProjectPaths({ cwd: workspaceRoot });
+
+    expect(paths.projectName).toBe('default');
+    expect(paths.projectRoot).toBe(workspaceRoot);
+    expect(paths.sourceRoot).toBe(join(workspaceRoot, 'src'));
+    expect(paths.viewsDir).toBe(join(workspaceRoot, 'src/views'));
+    expect(paths.clientDistDir).toBe(join(workspaceRoot, 'dist/client'));
+    expect(paths.serverDistDir).toBe(join(workspaceRoot, 'dist/server'));
+    expect(paths.entryClientDev).toBe('/src/views/entry-client.tsx');
+  });
+
+  it('resolves monorepo application paths from nest-cli.json', () => {
+    writeJson('nest-cli.json', {
+      monorepo: true,
+      root: 'apps/web',
+      sourceRoot: 'apps/web/src',
+      projects: {
+        web: {
+          type: 'application',
+          root: 'apps/web',
+          sourceRoot: 'apps/web/src',
+          compilerOptions: {
+            tsConfigPath: 'apps/web/tsconfig.app.json',
+          },
+        },
+      },
+    });
+    writeJson('apps/web/tsconfig.app.json', {
+      compilerOptions: {
+        outDir: '../../dist/apps/web',
+      },
+    });
+    mkdirSync(join(workspaceRoot, 'apps/web/src/views'), {
+      recursive: true,
+    });
+
+    const paths = resolveNestSsrProjectPaths({
+      cwd: workspaceRoot,
+      project: 'web',
+    });
+
+    expect(paths.projectName).toBe('web');
+    expect(paths.projectRoot).toBe(join(workspaceRoot, 'apps/web'));
+    expect(paths.viewsDir).toBe(join(workspaceRoot, 'apps/web/src/views'));
+    expect(paths.clientDistDir).toBe(
+      join(workspaceRoot, 'dist/apps/web/client'),
+    );
+    expect(paths.serverDistDir).toBe(
+      join(workspaceRoot, 'dist/apps/web/server'),
+    );
+    expect(paths.entryClientDev).toBe('/src/views/entry-client.tsx');
+    expect(paths.viteRoot).toBe(join(workspaceRoot, 'apps/web'));
+  });
+
+  it('auto-detects monorepo project from main filename', () => {
+    writeJson('nest-cli.json', {
+      monorepo: true,
+      root: 'apps/web',
+      projects: {
+        web: {
+          type: 'application',
+          root: 'apps/web',
+          sourceRoot: 'apps/web/src',
+          compilerOptions: {
+            tsConfigPath: 'apps/web/tsconfig.app.json',
+          },
+        },
+        api: {
+          type: 'application',
+          root: 'apps/api',
+          sourceRoot: 'apps/api/src',
+        },
+      },
+    });
+    writeJson('apps/web/tsconfig.app.json', {
+      compilerOptions: {
+        outDir: '../../dist/apps/web',
+      },
+    });
+
+    const paths = resolveNestSsrProjectPaths({
+      cwd: workspaceRoot,
+      mainFilename: join(workspaceRoot, 'dist/apps/web/main.js'),
+    });
+
+    expect(paths.projectName).toBe('web');
+    expect(paths.viewsDir).toBe(join(workspaceRoot, 'apps/web/src/views'));
+  });
+
+  it('honors NEST_SSR_PROJECT environment variable', () => {
+    writeJson('nest-cli.json', {
+      monorepo: true,
+      projects: {
+        web: {
+          type: 'application',
+          root: 'apps/web',
+          sourceRoot: 'apps/web/src',
+        },
+        api: {
+          type: 'application',
+          root: 'apps/api',
+          sourceRoot: 'apps/api/src',
+        },
+      },
+    });
+
+    process.env.NEST_SSR_PROJECT = 'api';
+
+    const paths = resolveNestSsrProjectPaths({ cwd: workspaceRoot });
+
+    expect(paths.projectName).toBe('api');
+    expect(paths.projectRoot).toBe(join(workspaceRoot, 'apps/api'));
+  });
+
+  it('supports custom viewsDir relative to project root', () => {
+    writeJson('nest-cli.json', {
+      sourceRoot: 'src',
+    });
+
+    const paths = resolveNestSsrProjectPaths({
+      cwd: workspaceRoot,
+      viewsDir: 'src/ui/pages',
+    });
+
+    expect(paths.viewsDir).toBe(join(workspaceRoot, 'src/ui/pages'));
+    expect(paths.entryClientDev).toBe('/src/ui/pages/entry-client.tsx');
+  });
+});

--- a/packages/react/src/config/nest-project-paths.interface.ts
+++ b/packages/react/src/config/nest-project-paths.interface.ts
@@ -1,0 +1,47 @@
+/**
+ * Resolved filesystem paths for SSR within a NestJS workspace.
+ * All absolute paths are normalized; dev URL paths are Vite-root-relative.
+ */
+export interface NestSsrProjectPaths {
+  /** Workspace root where nest-cli.json lives */
+  workspaceRoot: string;
+  /** Nest CLI project name */
+  projectName: string;
+  /** Application root directory (absolute) */
+  projectRoot: string;
+  /** Application source root (absolute), e.g. .../src or .../apps/web/src */
+  sourceRoot: string;
+  /** Views directory (absolute) */
+  viewsDir: string;
+  /** Vite server root (absolute) — equals projectRoot */
+  viteRoot: string;
+  /** Absolute path for the `@` alias (sourceRoot) */
+  aliasAt: string;
+  /** Dev client entry URL path, e.g. /src/views/entry-client.tsx */
+  entryClientDev: string;
+  /** Dev SSR entry path for vite.ssrLoadModule (leading slash) */
+  entryServerDev: string;
+  /** Dev HTML template (absolute) */
+  templateDev: string;
+  /** Production client bundle directory (absolute) */
+  clientDistDir: string;
+  /** Production server bundle directory (absolute) */
+  serverDistDir: string;
+  /** Nest backend compile output directory (absolute) */
+  nestDistDir: string;
+  /** Conventional layout paths relative to workspaceRoot for existence checks */
+  layoutProbePaths: string[];
+}
+
+export interface ResolveNestSsrProjectPathsOptions {
+  /** Explicit Nest CLI project name (monorepo) */
+  project?: string;
+  /** Override views directory, relative to projectRoot or absolute */
+  viewsDir?: string;
+  /** Starting directory for nest-cli.json discovery */
+  cwd?: string;
+  /** Override main entry for auto-detection (tests) */
+  mainFilename?: string;
+  /** Absolute path to package entry-server template fallback */
+  packageEntryServerPath?: string;
+}

--- a/packages/react/src/config/nest-project-resolver.ts
+++ b/packages/react/src/config/nest-project-resolver.ts
@@ -1,0 +1,359 @@
+import { existsSync, readFileSync } from 'fs';
+import { dirname, join, normalize, relative, resolve } from 'path';
+import type {
+  NestSsrProjectPaths,
+  ResolveNestSsrProjectPathsOptions,
+} from './nest-project-paths.interface';
+
+export const SSR_PROJECT_PATHS = 'SSR_PROJECT_PATHS';
+
+interface NestCliSsrOptions {
+  viewsDir?: string;
+  vitePort?: number;
+}
+
+interface NestCliProjectEntry {
+  type?: string;
+  root?: string;
+  entryFile?: string;
+  sourceRoot?: string;
+  compilerOptions?: {
+    tsConfigPath?: string;
+  };
+  ssr?: NestCliSsrOptions;
+}
+
+interface NestCliConfig {
+  monorepo?: boolean;
+  root?: string;
+  sourceRoot?: string;
+  projects?: Record<string, NestCliProjectEntry>;
+  compilerOptions?: {
+    tsConfigPath?: string;
+  };
+}
+
+const DEFAULT_VIEWS_SUBDIR = 'views';
+
+/**
+ * Resolve SSR paths from nest-cli.json for single-app and monorepo workspaces.
+ */
+export function resolveNestSsrProjectPaths(
+  options: ResolveNestSsrProjectPathsOptions = {},
+): NestSsrProjectPaths {
+  const startDir = resolve(options.cwd ?? process.cwd());
+  const workspaceRoot = findWorkspaceRoot(startDir);
+  const nestCli = readNestCliConfig(workspaceRoot);
+
+  const projectName = resolveProjectName(nestCli, workspaceRoot, options);
+  const projectEntry = getProjectEntry(nestCli, projectName);
+
+  const projectRoot = resolve(
+    workspaceRoot,
+    projectEntry.root ?? nestCli.root ?? '.',
+  );
+  const sourceRoot = resolve(
+    workspaceRoot,
+    projectEntry.sourceRoot ?? nestCli.sourceRoot ?? 'src',
+  );
+
+  const viewsDir = resolveViewsDir(
+    projectRoot,
+    sourceRoot,
+    projectEntry,
+    options.viewsDir,
+  );
+
+  const nestDistDir = resolveNestDistDir(
+    workspaceRoot,
+    projectName,
+    projectEntry,
+    nestCli,
+  );
+  const clientDistDir = join(nestDistDir, 'client');
+  const serverDistDir = join(nestDistDir, 'server');
+
+  const entryClientRelative = toViteUrlPath(
+    relative(projectRoot, join(viewsDir, 'entry-client.tsx')),
+  );
+  const userEntryServer = join(viewsDir, 'entry-server.tsx');
+  const entryServerDev = resolveEntryServerDevPath(
+    projectRoot,
+    userEntryServer,
+    options.packageEntryServerPath,
+  );
+
+  const layoutProbePaths = [
+    join(viewsDir, 'layout.tsx'),
+    join(viewsDir, 'layout', 'index.tsx'),
+    join(viewsDir, '_layout.tsx'),
+  ].map((absolutePath) =>
+    normalize(relative(workspaceRoot, absolutePath)).replace(/\\/g, '/'),
+  );
+
+  return {
+    workspaceRoot,
+    projectName,
+    projectRoot,
+    sourceRoot,
+    viewsDir,
+    viteRoot: projectRoot,
+    aliasAt: sourceRoot,
+    entryClientDev: entryClientRelative,
+    entryServerDev,
+    templateDev: join(viewsDir, 'index.html'),
+    clientDistDir,
+    serverDistDir,
+    nestDistDir,
+    layoutProbePaths,
+  };
+}
+
+function findWorkspaceRoot(startDir: string): string {
+  let current = startDir;
+  while (true) {
+    if (existsSync(join(current, 'nest-cli.json'))) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return startDir;
+    }
+    current = parent;
+  }
+}
+
+function readNestCliConfig(workspaceRoot: string): NestCliConfig {
+  const nestCliPath = join(workspaceRoot, 'nest-cli.json');
+  if (!existsSync(nestCliPath)) {
+    return {};
+  }
+
+  return JSON.parse(readFileSync(nestCliPath, 'utf-8')) as NestCliConfig;
+}
+
+function resolveProjectName(
+  nestCli: NestCliConfig,
+  workspaceRoot: string,
+  options: ResolveNestSsrProjectPathsOptions,
+): string {
+  if (options.project) {
+    assertProjectExists(nestCli, options.project);
+    return options.project;
+  }
+
+  const envProject = process.env.NEST_SSR_PROJECT;
+  if (envProject) {
+    assertProjectExists(nestCli, envProject);
+    return envProject;
+  }
+
+  const applicationProjects = getApplicationProjects(nestCli);
+  if (applicationProjects.length === 0) {
+    return 'default';
+  }
+
+  if (applicationProjects.length === 1 && !nestCli.monorepo) {
+    return applicationProjects[0].name;
+  }
+
+  const mainFilename = options.mainFilename ?? require.main?.filename;
+  if (mainFilename) {
+    const detected = detectProjectFromMainFile(
+      mainFilename,
+      workspaceRoot,
+      applicationProjects,
+      nestCli,
+    );
+    if (detected) {
+      return detected;
+    }
+  }
+
+  const defaultRoot = nestCli.root;
+  if (defaultRoot) {
+    const match = applicationProjects.find(
+      (project) =>
+        normalizeProjectRoot(project.entry.root ?? '.') ===
+        normalizeProjectRoot(defaultRoot),
+    );
+    if (match) {
+      return match.name;
+    }
+  }
+
+  if (applicationProjects.length === 1) {
+    return applicationProjects[0].name;
+  }
+
+  throw new Error(
+    'Could not determine Nest SSR project in monorepo. ' +
+      'Set RenderModule.forRoot({ project: "<name>" }) or NEST_SSR_PROJECT.',
+  );
+}
+
+function assertProjectExists(
+  nestCli: NestCliConfig,
+  projectName: string,
+): void {
+  if (projectName === 'default') {
+    return;
+  }
+
+  const projects = nestCli.projects ?? {};
+  if (!projects[projectName]) {
+    throw new Error(
+      `Nest SSR project "${projectName}" was not found in nest-cli.json.`,
+    );
+  }
+}
+
+function getApplicationProjects(nestCli: NestCliConfig): Array<{
+  name: string;
+  entry: NestCliProjectEntry;
+}> {
+  const projects = nestCli.projects ?? {};
+  const entries = Object.entries(projects)
+    .filter(([, entry]) => entry.type === 'application' || !entry.type)
+    .map(([name, entry]) => ({ name, entry }));
+
+  if (entries.length > 0) {
+    return entries;
+  }
+
+  return [
+    {
+      name: 'default',
+      entry: {
+        root: nestCli.root ?? '.',
+        sourceRoot: nestCli.sourceRoot ?? 'src',
+        compilerOptions: nestCli.compilerOptions,
+      },
+    },
+  ];
+}
+
+function getProjectEntry(
+  nestCli: NestCliConfig,
+  projectName: string,
+): NestCliProjectEntry {
+  if (projectName === 'default') {
+    return {
+      root: nestCli.root ?? '.',
+      sourceRoot: nestCli.sourceRoot ?? 'src',
+      compilerOptions: nestCli.compilerOptions,
+    };
+  }
+
+  const entry = nestCli.projects?.[projectName];
+  if (!entry) {
+    throw new Error(
+      `Nest SSR project "${projectName}" was not found in nest-cli.json.`,
+    );
+  }
+
+  return entry;
+}
+
+function detectProjectFromMainFile(
+  mainFilename: string,
+  workspaceRoot: string,
+  applicationProjects: Array<{ name: string; entry: NestCliProjectEntry }>,
+  nestCli: NestCliConfig,
+): string | null {
+  const normalizedMain = normalize(mainFilename);
+
+  for (const { name, entry } of applicationProjects) {
+    const nestDistDir = resolveNestDistDir(workspaceRoot, name, entry, nestCli);
+    if (normalizedMain.startsWith(nestDistDir)) {
+      return name;
+    }
+
+    const projectRoot = resolve(workspaceRoot, entry.root ?? '.');
+    if (normalizedMain.startsWith(projectRoot)) {
+      return name;
+    }
+  }
+
+  return null;
+}
+
+function resolveViewsDir(
+  projectRoot: string,
+  sourceRoot: string,
+  projectEntry: NestCliProjectEntry,
+  override?: string,
+): string {
+  const configured =
+    override ??
+    projectEntry.ssr?.viewsDir ??
+    `${relative(projectRoot, sourceRoot)}/${DEFAULT_VIEWS_SUBDIR}`;
+
+  if (configured.startsWith('/') || /^[A-Za-z]:\\/.test(configured)) {
+    return normalize(configured);
+  }
+
+  return normalize(join(projectRoot, configured));
+}
+
+function resolveNestDistDir(
+  workspaceRoot: string,
+  projectName: string,
+  projectEntry: NestCliProjectEntry,
+  nestCli: NestCliConfig,
+): string {
+  const tsConfigPath =
+    projectEntry.compilerOptions?.tsConfigPath ??
+    nestCli.compilerOptions?.tsConfigPath ??
+    (projectName === 'default' ? 'tsconfig.build.json' : undefined);
+
+  if (tsConfigPath) {
+    const fullTsConfigPath = join(workspaceRoot, tsConfigPath);
+    if (existsSync(fullTsConfigPath)) {
+      const tsconfig = JSON.parse(readFileSync(fullTsConfigPath, 'utf-8')) as {
+        compilerOptions?: { outDir?: string };
+      };
+      const outDir = tsconfig.compilerOptions?.outDir ?? 'dist';
+      return normalize(join(dirname(fullTsConfigPath), outDir));
+    }
+  }
+
+  if (projectName !== 'default' && nestCli.monorepo) {
+    return normalize(join(workspaceRoot, 'dist', projectName));
+  }
+
+  return normalize(join(workspaceRoot, 'dist'));
+}
+
+function resolveEntryServerDevPath(
+  projectRoot: string,
+  userEntryServer: string,
+  packageEntryServerPath?: string,
+): string {
+  if (existsSync(userEntryServer)) {
+    return toViteUrlPath(relative(projectRoot, userEntryServer));
+  }
+
+  if (packageEntryServerPath) {
+    const absolutePackagePath = normalize(packageEntryServerPath);
+    const relativeToProject = relative(projectRoot, absolutePackagePath);
+    if (!relativeToProject.startsWith('..')) {
+      return toViteUrlPath(relativeToProject);
+    }
+    return absolutePackagePath.replace(/\\/g, '/');
+  }
+
+  return toViteUrlPath(relative(projectRoot, userEntryServer));
+}
+
+function toViteUrlPath(relativePath: string): string {
+  const normalized = relativePath.replace(/\\/g, '/');
+  return normalized.startsWith('/') ? normalized : `/${normalized}`;
+}
+
+function normalizeProjectRoot(root: string): string {
+  return root
+    .replace(/\\/g, '/')
+    .replace(/^\.\/?/, '')
+    .replace(/\/$/, '');
+}

--- a/packages/react/src/config/ssr-project-paths.token.ts
+++ b/packages/react/src/config/ssr-project-paths.token.ts
@@ -1,0 +1,5 @@
+export { SSR_PROJECT_PATHS } from './nest-project-resolver';
+export type {
+  NestSsrProjectPaths,
+  ResolveNestSsrProjectPathsOptions,
+} from './nest-project-paths.interface';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -36,7 +36,14 @@ export type {
   RenderConfig,
   SSRMode,
   ContextFactory,
-} from './interfaces/render-config.interface';
+  NestSsrProjectPaths,
+  ResolveNestSsrProjectPathsOptions,
+} from './interfaces';
+
+export {
+  resolveNestSsrProjectPaths,
+  SSR_PROJECT_PATHS,
+} from './config/nest-project-resolver';
 
 export type {
   RenderResponse,

--- a/packages/react/src/interfaces/index.ts
+++ b/packages/react/src/interfaces/index.ts
@@ -10,6 +10,14 @@ export type {
   ContextFactory,
   CspNonceFactory,
 } from './render-config.interface';
+export type {
+  NestSsrProjectPaths,
+  ResolveNestSsrProjectPathsOptions,
+} from '../config/nest-project-paths.interface';
+export {
+  resolveNestSsrProjectPaths,
+  SSR_PROJECT_PATHS,
+} from '../config/nest-project-resolver';
 export type { RenderResponse, HeadData } from './render-response.interface';
 export type {
   LayoutProps,

--- a/packages/react/src/interfaces/render-config.interface.ts
+++ b/packages/react/src/interfaces/render-config.interface.ts
@@ -93,6 +93,29 @@ export interface ViteConfig {
  */
 export interface RenderConfig {
   /**
+   * Nest CLI project name in a monorepo workspace.
+   * When omitted, the active project is inferred from NEST_SSR_PROJECT,
+   * the running main file path, or the default project in nest-cli.json.
+   *
+   * @example
+   * ```typescript
+   * RenderModule.forRoot({ project: 'web' })
+   * ```
+   */
+  project?: string;
+
+  /**
+   * Override the views directory for SSR assets.
+   * Relative to the Nest project root unless an absolute path is provided.
+   *
+   * @example
+   * ```typescript
+   * RenderModule.forRoot({ viewsDir: 'src/ui/pages' })
+   * ```
+   */
+  viewsDir?: string;
+
+  /**
    * SSR rendering mode
    * - 'string': Traditional renderToString - atomic responses, proper HTTP status codes (default)
    * - 'stream': Modern renderToPipeableStream - better TTFB, Suspense support (advanced)

--- a/packages/react/src/render/__tests__/render.module.spec.ts
+++ b/packages/react/src/render/__tests__/render.module.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { RenderModule } from '../render.module';
+import { SSR_PROJECT_PATHS } from '../../config/nest-project-resolver';
 
 describe('RenderModule JSON API config', () => {
   it('should register JSON_API in forRoot()', () => {
@@ -41,5 +42,40 @@ describe('RenderModule JSON API config', () => {
     ).useFactory({ jsonApi: true });
 
     expect(value).toBe(true);
+  });
+});
+
+describe('RenderModule project paths', () => {
+  it('should register SSR_PROJECT_PATHS in forRoot()', () => {
+    const dynamicModule = RenderModule.forRoot();
+    const pathsProvider = dynamicModule.providers?.find(
+      (provider) =>
+        typeof provider === 'object' &&
+        provider !== null &&
+        'provide' in provider &&
+        provider.provide === SSR_PROJECT_PATHS,
+    );
+
+    expect(pathsProvider).toBeDefined();
+    expect(pathsProvider).toMatchObject({
+      provide: SSR_PROJECT_PATHS,
+    });
+  });
+
+  it('should register SSR_PROJECT_PATHS in forRootAsync()', () => {
+    const dynamicModule = RenderModule.forRootAsync({
+      useFactory: async () => ({ project: 'web' }),
+    });
+    const pathsProvider = dynamicModule.providers?.find(
+      (provider) =>
+        typeof provider === 'object' &&
+        provider !== null &&
+        'provide' in provider &&
+        provider.provide === SSR_PROJECT_PATHS,
+    );
+
+    expect(pathsProvider).toBeDefined();
+    expect(typeof pathsProvider).toBe('object');
+    expect('useFactory' in (pathsProvider as object)).toBe(true);
   });
 });

--- a/packages/react/src/render/__tests__/render.service.spec.ts
+++ b/packages/react/src/render/__tests__/render.service.spec.ts
@@ -70,6 +70,9 @@ import { StreamingErrorHandler } from '../streaming-error-handler';
 import { StringRenderer } from '../renderers/string-renderer';
 import { StreamRenderer } from '../renderers/stream-renderer';
 import { readFileSync, existsSync } from 'fs';
+import { createDefaultTestProjectPaths } from './test-project-paths';
+
+const defaultProjectPaths = createDefaultTestProjectPaths('/project');
 
 // Type helpers for mocks
 type MockedViteModule = {
@@ -152,7 +155,7 @@ describe('RenderService', () => {
     });
 
     // Create dependencies
-    templateParser = new TemplateParserService();
+    templateParser = new TemplateParserService(defaultProjectPaths);
     streamingErrorHandler = new StreamingErrorHandler();
     stringRenderer = new StringRenderer(templateParser);
     streamRenderer = new StreamRenderer(templateParser, streamingErrorHandler);
@@ -188,7 +191,11 @@ describe('RenderService', () => {
     it('should initialize in development mode', () => {
       process.env.NODE_ENV = 'development';
 
-      service = new RenderService(stringRenderer, streamRenderer);
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+      );
 
       expect(service).toBeDefined();
       expect(existsSync).toHaveBeenCalled();
@@ -198,20 +205,33 @@ describe('RenderService', () => {
     it('should initialize in production mode', () => {
       process.env.NODE_ENV = 'production';
 
-      service = new RenderService(stringRenderer, streamRenderer);
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+      );
 
       expect(service).toBeDefined();
     });
 
     it('should use string mode by default', () => {
-      service = new RenderService(stringRenderer, streamRenderer);
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+      );
 
       expect(service).toBeDefined();
       // Default SSR mode is 'string' based on constructor logic
     });
 
     it('should use provided SSR mode', () => {
-      service = new RenderService(stringRenderer, streamRenderer, 'stream');
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+        'stream',
+      );
 
       expect(service).toBeDefined();
     });
@@ -220,7 +240,7 @@ describe('RenderService', () => {
       vi.mocked(existsSync).mockReturnValue(false);
 
       expect(() => {
-        new RenderService(stringRenderer, streamRenderer);
+        new RenderService(stringRenderer, streamRenderer, defaultProjectPaths);
       }).toThrow('Template file not found');
     });
 
@@ -230,7 +250,7 @@ describe('RenderService', () => {
       });
 
       expect(() => {
-        new RenderService(stringRenderer, streamRenderer);
+        new RenderService(stringRenderer, streamRenderer, defaultProjectPaths);
       }).toThrow('Failed to read template file');
     });
 
@@ -251,7 +271,11 @@ describe('RenderService', () => {
         throw new Error('Unexpected path');
       });
 
-      service = new RenderService(stringRenderer, streamRenderer);
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+      );
 
       expect(service).toBeDefined();
       // Should have loaded both manifests
@@ -270,6 +294,7 @@ describe('RenderService', () => {
       service = new RenderService(
         stringRenderer,
         streamRenderer,
+        defaultProjectPaths,
         'string',
         defaultHead,
       );
@@ -280,7 +305,11 @@ describe('RenderService', () => {
 
   describe('setViteServer', () => {
     beforeEach(() => {
-      service = new RenderService(stringRenderer, streamRenderer);
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+      );
     });
 
     it('should set Vite server instance', () => {
@@ -293,11 +322,21 @@ describe('RenderService', () => {
 
   describe('render', () => {
     beforeEach(() => {
-      service = new RenderService(stringRenderer, streamRenderer, 'string');
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+        'string',
+      );
     });
 
     it('should throw error if response missing in stream mode', async () => {
-      service = new RenderService(stringRenderer, streamRenderer, 'stream');
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+        'stream',
+      );
 
       await expect(service.render('views/test', {})).rejects.toThrow(
         'Response object is required for streaming SSR mode',
@@ -314,6 +353,7 @@ describe('RenderService', () => {
       service = new RenderService(
         stringRenderer,
         streamRenderer,
+        defaultProjectPaths,
         'string',
         defaultHead,
       );
@@ -355,6 +395,7 @@ describe('RenderService', () => {
       service = new RenderService(
         stringRenderer,
         streamRenderer,
+        defaultProjectPaths,
         'string',
         defaultHead,
       );
@@ -416,7 +457,12 @@ describe('RenderService', () => {
 
   describe('renderToString mode', () => {
     beforeEach(() => {
-      service = new RenderService(stringRenderer, streamRenderer, 'string');
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+        'string',
+      );
 
       service.setViteServer(mockVite as ViteDevServer);
     });
@@ -486,7 +532,12 @@ describe('RenderService', () => {
 
   describe('renderToStream mode', () => {
     beforeEach(() => {
-      service = new RenderService(stringRenderer, streamRenderer, 'stream');
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+        'stream',
+      );
 
       service.setViteServer(mockVite as ViteDevServer);
     });
@@ -612,7 +663,12 @@ describe('RenderService', () => {
 
   describe('error handling', () => {
     beforeEach(() => {
-      service = new RenderService(stringRenderer, streamRenderer, 'string');
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+        'string',
+      );
 
       service.setViteServer(mockVite as ViteDevServer);
     });
@@ -635,7 +691,12 @@ describe('RenderService', () => {
 
     it('should handle shell error in stream mode', async () => {
       const mockStreamResponse = createMockStreamResponse();
-      service = new RenderService(stringRenderer, streamRenderer, 'stream');
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+        'stream',
+      );
 
       service.setViteServer(mockVite as ViteDevServer);
 
@@ -678,7 +739,12 @@ describe('RenderService', () => {
 
     it('should handle streaming error after headers sent', async () => {
       const mockStreamResponse = createMockStreamResponse();
-      service = new RenderService(stringRenderer, streamRenderer, 'stream');
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+        'stream',
+      );
 
       service.setViteServer(mockVite as ViteDevServer);
 
@@ -743,7 +809,12 @@ describe('RenderService', () => {
         throw new Error('Unexpected path');
       });
 
-      service = new RenderService(stringRenderer, streamRenderer, 'string');
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+        'string',
+      );
     });
 
     it('should use manifest for client script in production', async () => {
@@ -766,7 +837,12 @@ describe('RenderService', () => {
 
   describe('real-world scenarios', () => {
     beforeEach(() => {
-      service = new RenderService(stringRenderer, streamRenderer, 'string');
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+        'string',
+      );
 
       service.setViteServer(mockVite as ViteDevServer);
     });
@@ -857,7 +933,12 @@ describe('RenderService', () => {
 
   describe('getRootLayout', () => {
     beforeEach(() => {
-      service = new RenderService(stringRenderer, streamRenderer, 'string');
+      service = new RenderService(
+        stringRenderer,
+        streamRenderer,
+        defaultProjectPaths,
+        'string',
+      );
     });
 
     it('should return null when no root layout file exists', async () => {
@@ -1117,6 +1198,7 @@ describe('RenderService', () => {
       const prodService = new RenderService(
         stringRenderer,
         streamRenderer,
+        defaultProjectPaths,
         'string',
       );
 
@@ -1152,6 +1234,7 @@ describe('RenderService', () => {
       const prodService = new RenderService(
         stringRenderer,
         streamRenderer,
+        defaultProjectPaths,
         'string',
       );
 
@@ -1183,6 +1266,7 @@ describe('RenderService', () => {
       const prodService = new RenderService(
         stringRenderer,
         streamRenderer,
+        defaultProjectPaths,
         'string',
       );
 

--- a/packages/react/src/render/__tests__/stream-renderer.spec.ts
+++ b/packages/react/src/render/__tests__/stream-renderer.spec.ts
@@ -4,6 +4,9 @@ import { StreamRenderer } from '../renderers/stream-renderer';
 import { TemplateParserService } from '../template-parser.service';
 import { StreamingErrorHandler } from '../streaming-error-handler';
 import type { StreamRenderContext } from '../renderers/stream-renderer';
+import { createDefaultTestProjectPaths } from './test-project-paths';
+
+const defaultProjectPaths = createDefaultTestProjectPaths('/project');
 
 const serverModule = vi.hoisted(() => ({
   loadServerModule: vi.fn(),
@@ -22,7 +25,7 @@ describe('StreamRenderer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     renderer = new StreamRenderer(
-      new TemplateParserService(),
+      new TemplateParserService(defaultProjectPaths),
       new StreamingErrorHandler(),
     );
   });
@@ -80,6 +83,8 @@ describe('StreamRenderer', () => {
       },
       serverManifest: null,
       entryServerPath: '/src/views/entry-server.tsx',
+      serverDistDir: defaultProjectPaths.serverDistDir,
+      entryClientDev: defaultProjectPaths.entryClientDev,
       isDevelopment: false,
       nonce: 'nonce-123',
     };

--- a/packages/react/src/render/__tests__/string-renderer.spec.ts
+++ b/packages/react/src/render/__tests__/string-renderer.spec.ts
@@ -3,6 +3,9 @@ import type { ViteDevServer } from 'vite';
 import { StringRenderer } from '../renderers/string-renderer';
 import type { StringRenderContext } from '../renderers/string-renderer';
 import { TemplateParserService } from '../template-parser.service';
+import { createDefaultTestProjectPaths } from './test-project-paths';
+
+const defaultProjectPaths = createDefaultTestProjectPaths('/project');
 
 // Mock components
 const MockPage = () => null;
@@ -33,7 +36,7 @@ describe('StringRenderer', () => {
   let templateParser: TemplateParserService;
 
   beforeEach(() => {
-    templateParser = new TemplateParserService();
+    templateParser = new TemplateParserService(defaultProjectPaths);
     renderer = new StringRenderer(templateParser);
   });
 
@@ -77,6 +80,8 @@ describe('StringRenderer', () => {
         manifest: clientManifest,
         serverManifest: manifestWithoutEntry,
         entryServerPath: 'src/views/entry-server.tsx',
+        serverDistDir: defaultProjectPaths.serverDistDir,
+        entryClientDev: defaultProjectPaths.entryClientDev,
         isDevelopment: false,
       };
 
@@ -98,6 +103,8 @@ describe('StringRenderer', () => {
         manifest: clientManifest,
         serverManifest: null,
         entryServerPath: 'src/views/entry-server.tsx',
+        serverDistDir: defaultProjectPaths.serverDistDir,
+        entryClientDev: defaultProjectPaths.entryClientDev,
         isDevelopment: false,
       };
 
@@ -127,6 +134,8 @@ describe('StringRenderer', () => {
         manifest: clientManifest,
         serverManifest: manifestNotEntry,
         entryServerPath: 'src/views/entry-server.tsx',
+        serverDistDir: defaultProjectPaths.serverDistDir,
+        entryClientDev: defaultProjectPaths.entryClientDev,
         isDevelopment: false,
       };
 
@@ -162,6 +171,8 @@ describe('StringRenderer', () => {
         manifest: null,
         serverManifest: null,
         entryServerPath: '/src/views/entry-server.tsx',
+        serverDistDir: defaultProjectPaths.serverDistDir,
+        entryClientDev: defaultProjectPaths.entryClientDev,
         isDevelopment: true,
         ...overrides,
       };
@@ -351,6 +362,8 @@ describe('StringRenderer', () => {
         manifest: null,
         serverManifest: null,
         entryServerPath: '/src/views/entry-server.tsx',
+        serverDistDir: defaultProjectPaths.serverDistDir,
+        entryClientDev: defaultProjectPaths.entryClientDev,
         isDevelopment: true,
       };
 
@@ -400,6 +413,8 @@ describe('StringRenderer', () => {
         manifest: null,
         serverManifest: null,
         entryServerPath: '/src/views/entry-server.tsx',
+        serverDistDir: defaultProjectPaths.serverDistDir,
+        entryClientDev: defaultProjectPaths.entryClientDev,
         isDevelopment: false,
         ...overrides,
       };
@@ -624,6 +639,8 @@ describe('StringRenderer', () => {
         manifest: null,
         serverManifest: null,
         entryServerPath: '/src/views/entry-server.tsx',
+        serverDistDir: defaultProjectPaths.serverDistDir,
+        entryClientDev: defaultProjectPaths.entryClientDev,
         isDevelopment: true,
       };
 
@@ -654,6 +671,8 @@ describe('StringRenderer', () => {
         manifest: null,
         serverManifest: null,
         entryServerPath: '/src/views/entry-server.tsx',
+        serverDistDir: defaultProjectPaths.serverDistDir,
+        entryClientDev: defaultProjectPaths.entryClientDev,
         isDevelopment: false,
       };
 

--- a/packages/react/src/render/__tests__/template-parser.service.spec.ts
+++ b/packages/react/src/render/__tests__/template-parser.service.spec.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TemplateParserService } from '../template-parser.service';
 import type { HeadData } from '../../interfaces';
+import { createDefaultTestProjectPaths } from './test-project-paths';
+
+const defaultProjectPaths = createDefaultTestProjectPaths('/project');
 
 describe('TemplateParserService', () => {
   let service: TemplateParserService;
 
   beforeEach(() => {
-    service = new TemplateParserService();
+    service = new TemplateParserService(defaultProjectPaths);
   });
 
   describe('parseTemplate', () => {

--- a/packages/react/src/render/__tests__/test-project-paths.ts
+++ b/packages/react/src/render/__tests__/test-project-paths.ts
@@ -1,0 +1,31 @@
+import { join } from 'path';
+import type { NestSsrProjectPaths } from '../../config/nest-project-paths.interface';
+
+export function createDefaultTestProjectPaths(
+  workspaceRoot = '/project',
+): NestSsrProjectPaths {
+  const projectRoot = workspaceRoot;
+  const sourceRoot = join(projectRoot, 'src');
+  const viewsDir = join(sourceRoot, 'views');
+
+  return {
+    workspaceRoot,
+    projectName: 'default',
+    projectRoot,
+    sourceRoot,
+    viewsDir,
+    viteRoot: projectRoot,
+    aliasAt: sourceRoot,
+    entryClientDev: '/src/views/entry-client.tsx',
+    entryServerDev: '/src/views/entry-server.tsx',
+    templateDev: join(viewsDir, 'index.html'),
+    clientDistDir: join(projectRoot, 'dist/client'),
+    serverDistDir: join(projectRoot, 'dist/server'),
+    nestDistDir: join(projectRoot, 'dist'),
+    layoutProbePaths: [
+      'src/views/layout.tsx',
+      'src/views/layout/index.tsx',
+      'src/views/_layout.tsx',
+    ],
+  };
+}

--- a/packages/react/src/render/__tests__/vite-initializer.service.spec.ts
+++ b/packages/react/src/render/__tests__/vite-initializer.service.spec.ts
@@ -6,6 +6,10 @@ vi.mock('vite', () => ({
   createServer: vi.fn(),
 }));
 
+vi.mock('@vitejs/plugin-react', () => ({
+  default: vi.fn(() => 'react-plugin'),
+}));
+
 // Mock http-proxy-middleware
 vi.mock('http-proxy-middleware', () => ({
   createProxyMiddleware: vi.fn().mockReturnValue('proxy-middleware'),
@@ -36,6 +40,9 @@ import { RenderService } from '../render.service';
 import { createServer as createViteServer } from 'vite';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { detectAdapterType } from '../adapters';
+import { createDefaultTestProjectPaths } from './test-project-paths';
+
+const defaultProjectPaths = createDefaultTestProjectPaths('/project');
 
 describe('ViteInitializerService', () => {
   let service: ViteInitializerService;
@@ -105,6 +112,7 @@ describe('ViteInitializerService', () => {
     return new ViteInitializerService(
       mockRenderService as RenderService,
       mockHttpAdapterHost,
+      defaultProjectPaths,
       viteConfig,
     );
   }
@@ -152,8 +160,15 @@ describe('ViteInitializerService', () => {
 
       const [config] = vi.mocked(createViteServer).mock.calls[0] as [any];
       expect(config).toMatchObject({
+        root: defaultProjectPaths.viteRoot,
+        configFile: false,
         server: { middlewareMode: true },
         appType: 'custom',
+        resolve: {
+          alias: {
+            '@': defaultProjectPaths.aliasAt,
+          },
+        },
       });
       // hmr port is an OS-assigned ephemeral port — a literal 0 is NOT
       // acceptable: Vite 8 treats 0 as unset and binds the fixed default

--- a/packages/react/src/render/render.module.ts
+++ b/packages/react/src/render/render.module.ts
@@ -1,5 +1,6 @@
 import { Global, Module, DynamicModule, Provider } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
+import { join } from 'path';
 import { RenderService } from './render.service';
 import { RenderInterceptor } from './render.interceptor';
 import { TemplateParserService } from './template-parser.service';
@@ -8,6 +9,40 @@ import { ViteInitializerService } from './vite-initializer.service';
 import { StringRenderer, StreamRenderer } from './renderers';
 import { setEnvironmentOverride } from './environment.util';
 import type { RenderConfig } from '../interfaces';
+import {
+  resolveNestSsrProjectPaths,
+  SSR_PROJECT_PATHS,
+} from '../config/nest-project-resolver';
+
+function createProjectPathsProvider(
+  config?: RenderConfig,
+  configInject?: string,
+): Provider {
+  if (configInject) {
+    return {
+      provide: SSR_PROJECT_PATHS,
+      useFactory: (resolvedConfig: RenderConfig) =>
+        resolveNestSsrProjectPaths({
+          project: resolvedConfig?.project,
+          viewsDir: resolvedConfig?.viewsDir,
+          packageEntryServerPath: join(
+            __dirname,
+            '../templates/entry-server.tsx',
+          ),
+        }),
+      inject: [configInject],
+    };
+  }
+
+  return {
+    provide: SSR_PROJECT_PATHS,
+    useValue: resolveNestSsrProjectPaths({
+      project: config?.project,
+      viewsDir: config?.viewsDir,
+      packageEntryServerPath: join(__dirname, '../templates/entry-server.tsx'),
+    }),
+  };
+}
 
 @Global()
 @Module({
@@ -62,6 +97,7 @@ export class RenderModule {
     }
 
     const providers: Provider[] = [
+      createProjectPathsProvider(config),
       RenderService,
       TemplateParserService,
       StreamingErrorHandler,
@@ -213,6 +249,7 @@ export class RenderModule {
 
     const providers: Provider[] = [
       configProvider,
+      createProjectPathsProvider(undefined, 'RENDER_CONFIG'),
       RenderService,
       TemplateParserService,
       StreamingErrorHandler,

--- a/packages/react/src/render/render.service.ts
+++ b/packages/react/src/render/render.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject, Logger, Optional } from '@nestjs/common';
 import { readFileSync, existsSync } from 'fs';
-import { join, relative } from 'path';
+import { join } from 'path';
 import type { ViteDevServer } from 'vite';
 import type {
   SSRMode,
@@ -8,6 +8,8 @@ import type {
   SegmentResponse,
   SSRResponse,
 } from '../interfaces';
+import type { NestSsrProjectPaths } from '../config/nest-project-paths.interface';
+import { SSR_PROJECT_PATHS } from '../config/nest-project-resolver';
 import { StringRenderer } from './renderers/string-renderer';
 import { StreamRenderer } from './renderers/stream-renderer';
 import type { RendererContext, ViteManifest } from './server-module-loader';
@@ -48,6 +50,8 @@ export class RenderService {
   constructor(
     private readonly stringRenderer: StringRenderer,
     private readonly streamRenderer: StreamRenderer,
+    @Inject(SSR_PROJECT_PATHS)
+    private readonly projectPaths: NestSsrProjectPaths,
     @Optional() @Inject('SSR_MODE') ssrMode?: SSRMode,
     @Optional() @Inject('DEFAULT_HEAD') private readonly defaultHead?: HeadData,
     @Optional() @Inject('CUSTOM_TEMPLATE') customTemplate?: string,
@@ -58,15 +62,7 @@ export class RenderService {
     // Default to 'string' mode - simpler, atomic responses, proper HTTP status codes
     this.ssrMode = ssrMode || (process.env.SSR_MODE as SSRMode) || 'string';
 
-    // Resolve entry-server.tsx path for Vite
-    const absoluteServerPath = join(__dirname, '/templates/entry-server.tsx');
-    const relativeServerPath = relative(process.cwd(), absoluteServerPath);
-
-    if (relativeServerPath.startsWith('..')) {
-      this.entryServerPath = absoluteServerPath;
-    } else {
-      this.entryServerPath = '/' + relativeServerPath.replace(/\\/g, '/');
-    }
+    this.entryServerPath = this.projectPaths.entryServerDev;
 
     // Load HTML template
     this.template = this.loadTemplate(customTemplate);
@@ -98,7 +94,7 @@ export class RenderService {
 
     const customTemplatePath = customTemplate.startsWith('/')
       ? customTemplate
-      : join(process.cwd(), customTemplate);
+      : join(this.projectPaths.workspaceRoot, customTemplate);
 
     if (!existsSync(customTemplatePath)) {
       throw new Error(
@@ -126,7 +122,7 @@ export class RenderService {
         join(__dirname, '../src/templates/index.html'),
         join(__dirname, '../../src/templates/index.html'),
       ];
-      const localTemplatePath = join(process.cwd(), 'src/views/index.html');
+      const localTemplatePath = this.projectPaths.templateDev;
 
       const foundPackageTemplate = packageTemplatePaths.find((p) =>
         existsSync(p),
@@ -147,7 +143,7 @@ export class RenderService {
         );
       }
     } else {
-      templatePath = join(process.cwd(), 'dist/client/index.html');
+      templatePath = join(this.projectPaths.clientDistDir, 'index.html');
 
       if (!existsSync(templatePath)) {
         throw new Error(
@@ -169,7 +165,10 @@ export class RenderService {
   }
 
   private loadManifests(): void {
-    const manifestPath = join(process.cwd(), 'dist/client/.vite/manifest.json');
+    const manifestPath = join(
+      this.projectPaths.clientDistDir,
+      '.vite/manifest.json',
+    );
     if (existsSync(manifestPath)) {
       this.manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
     } else {
@@ -179,8 +178,8 @@ export class RenderService {
     }
 
     const serverManifestPath = join(
-      process.cwd(),
-      'dist/server/.vite/manifest.json',
+      this.projectPaths.serverDistDir,
+      '.vite/manifest.json',
     );
     if (existsSync(serverManifestPath)) {
       this.serverManifest = JSON.parse(
@@ -220,14 +219,10 @@ export class RenderService {
       // In development, use Vite's SSR module loader
       if (this.vite) {
         if (!this.rootLayoutDevPath) {
-          const conventionalPaths = [
-            'src/views/layout.tsx',
-            'src/views/layout/index.tsx',
-            'src/views/_layout.tsx',
-          ];
+          const conventionalPaths = this.projectPaths.layoutProbePaths;
           this.rootLayoutDevPath =
             conventionalPaths.find((path) =>
-              existsSync(join(process.cwd(), path)),
+              existsSync(join(this.projectPaths.workspaceRoot, path)),
             ) ?? null;
           if (this.rootLayoutDevPath) {
             this.logger.log(`✓ Found root layout at ${this.rootLayoutDevPath}`);
@@ -249,8 +244,8 @@ export class RenderService {
         // In production, get layout from entry-server bundle
         // Vite bundles everything into entry-server.mjs, so we can't import separate files
         const entryServerPath = join(
-          process.cwd(),
-          'dist/server/entry-server.mjs',
+          this.projectPaths.serverDistDir,
+          'entry-server.mjs',
         );
         if (existsSync(entryServerPath)) {
           const entryModule = await import(entryServerPath);
@@ -359,8 +354,10 @@ export class RenderService {
       manifest: this.manifest,
       serverManifest: this.serverManifest,
       entryServerPath: this.entryServerPath,
+      serverDistDir: this.projectPaths.serverDistDir,
       isDevelopment: this.isDevelopment,
       nonce,
+      entryClientDev: this.projectPaths.entryClientDev,
     };
   }
 

--- a/packages/react/src/render/server-module-loader.ts
+++ b/packages/react/src/render/server-module-loader.ts
@@ -1,4 +1,5 @@
 import type { ViteDevServer } from 'vite';
+import { join } from 'path';
 
 export interface ViteManifest {
   [key: string]: {
@@ -20,9 +21,12 @@ export interface RendererContext {
   manifest: ViteManifest | null;
   serverManifest: ViteManifest | null;
   entryServerPath: string;
+  serverDistDir: string;
   isDevelopment: boolean;
   /** CSP nonce for injected script tags, when the app provides one */
   nonce?: string;
+  /** Dev client entry URL path relative to the Vite root */
+  entryClientDev: string;
 }
 
 /**
@@ -49,7 +53,10 @@ const SERVER_BUNDLE_ERROR =
  * Production: from the built server bundle, resolved via the Vite manifest.
  */
 export async function loadServerModule(
-  context: Pick<RendererContext, 'vite' | 'serverManifest' | 'entryServerPath'>,
+  context: Pick<
+    RendererContext,
+    'vite' | 'serverManifest' | 'entryServerPath' | 'serverDistDir'
+  >,
 ): Promise<ServerEntryModule> {
   if (context.vite) {
     return (await context.vite.ssrLoadModule(
@@ -65,6 +72,6 @@ export async function loadServerModule(
     throw new Error(SERVER_BUNDLE_ERROR);
   }
 
-  const serverPath = `${process.cwd()}/dist/server/${manifestEntry[1].file}`;
+  const serverPath = join(context.serverDistDir, manifestEntry[1].file);
   return (await import(serverPath)) as ServerEntryModule;
 }

--- a/packages/react/src/render/template-parser.service.ts
+++ b/packages/react/src/render/template-parser.service.ts
@@ -1,7 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
 import { uneval } from 'devalue';
 import escapeHtml from 'escape-html';
 import type { TemplateParts, HeadData } from '../interfaces';
+import type { NestSsrProjectPaths } from '../config/nest-project-paths.interface';
+import { SSR_PROJECT_PATHS } from '../config/nest-project-resolver';
 import { serializeLayoutMetadata } from './component-name.util';
 
 /**
@@ -29,6 +31,11 @@ interface ViteManifest {
 @Injectable()
 export class TemplateParserService {
   private readonly logger = new Logger(TemplateParserService.name);
+
+  constructor(
+    @Inject(SSR_PROJECT_PATHS)
+    private readonly projectPaths: NestSsrProjectPaths,
+  ) {}
 
   // Mapping of HeadData fields to their HTML tag renderers
   // Order matters: title and description first for SEO best practices
@@ -160,7 +167,7 @@ window.__LAYOUTS__ = ${uneval(layoutMetadata)};
     const nonceAttr = this.nonceAttribute(nonce);
 
     if (isDevelopment) {
-      return `<script type="module"${nonceAttr} src="/src/views/entry-client.tsx"></script>`;
+      return `<script type="module"${nonceAttr} src="${this.projectPaths.entryClientDev}"></script>`;
     }
 
     const entry = this.findClientEntry(manifest);

--- a/packages/react/src/render/vite-initializer.service.ts
+++ b/packages/react/src/render/vite-initializer.service.ts
@@ -13,6 +13,8 @@ import type { AddressInfo, Socket } from 'node:net';
 import { RenderService } from './render.service';
 import type { ViteConfig } from '../interfaces';
 import type { ViteDevServer } from 'vite';
+import type { NestSsrProjectPaths } from '../config/nest-project-paths.interface';
+import { SSR_PROJECT_PATHS } from '../config/nest-project-resolver';
 import { detectAdapterType } from './adapters';
 import { isDevelopmentEnv, warnIfNodeEnvUnset } from './environment.util';
 
@@ -68,6 +70,8 @@ export class ViteInitializerService
   constructor(
     private readonly renderService: RenderService,
     private readonly httpAdapterHost: HttpAdapterHost,
+    @Inject(SSR_PROJECT_PATHS)
+    private readonly projectPaths: NestSsrProjectPaths,
     @Optional() @Inject('VITE_CONFIG') viteConfig?: ViteConfig,
   ) {
     this.vitePort = viteConfig?.port || 5173;
@@ -116,6 +120,7 @@ export class ViteInitializerService
     try {
       // Dynamically import Vite (ESM)
       const { createServer: createViteServer } = await import('vite');
+      const react = (await import('@vitejs/plugin-react')).default;
 
       // An OS-assigned free port for the HMR WebSocket avoids conflicts with
       // the external Vite dev server ("Port 5173 is already in use") and
@@ -125,6 +130,18 @@ export class ViteInitializerService
       // because Vite 8 treats 0 as unset and binds the fixed default 24678.
       const hmrPort = await getEphemeralPort();
       const creating = createViteServer({
+        root: this.projectPaths.viteRoot,
+        configFile: false,
+        plugins: [react({})],
+        resolve: {
+          alias: {
+            '@': this.projectPaths.aliasAt,
+          },
+          dedupe: ['react', 'react-dom', '@nestjs-ssr/react'],
+        },
+        ssr: {
+          noExternal: ['@nestjs-ssr/react'],
+        },
         server: { middlewareMode: true, hmr: { port: hmrPort } },
         appType: 'custom',
       });
@@ -215,8 +232,7 @@ export class ViteInitializerService
       if (!httpAdapter) return;
 
       const app = httpAdapter.getInstance();
-      const { join } = require('path');
-      const staticPath = join(process.cwd(), 'dist/client');
+      const staticPath = this.projectPaths.clientDistDir;
       const adapterType = detectAdapterType(this.httpAdapterHost);
 
       if (adapterType === 'fastify') {


### PR DESCRIPTION
- Resolve SSR paths from nest-cli.json for single-app and monorepo workspaces
- Inject SSR_PROJECT_PATHS into RenderModule and runtime services
- Configure embedded Vite with project root and alias instead of monorepo cwd
- Add init --project flag and per-app vite config scaffolding
- Add resolver, init, and integration tests for monorepo path handling